### PR TITLE
Improve bullet particle effects

### DIFF
--- a/player/bullet.tscn
+++ b/player/bullet.tscn
@@ -5,353 +5,104 @@
 [ext_resource path="res://player/fx_bullet_explodewav.wav" type="AudioStream" id=3]
 
 [sub_resource type="SpatialMaterial" id=1]
-
-render_priority = 0
-flags_transparent = false
-flags_unshaded = false
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
-flags_do_not_receive_shadows = false
-flags_disable_ambient_light = false
-flags_ensure_correct_normals = false
-vertex_color_use_as_albedo = false
-vertex_color_is_srgb = false
-params_diffuse_mode = 0
-params_specular_mode = 0
-params_blend_mode = 0
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
-params_billboard_mode = 0
-params_billboard_keep_scale = false
-params_grow = false
-params_use_alpha_scissor = false
 albedo_color = Color( 0, 0, 0, 1 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
 roughness = 0.0
-roughness_texture_channel = 0
 emission_enabled = true
 emission = Color( 0.109804, 0.894118, 1, 1 )
 emission_energy = 7.34
 emission_operator = 0
 emission_on_uv2 = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_enable = false
-_sections_unfolded = [ "Albedo", "Emission", "Flags" ]
 
 [sub_resource type="SphereMesh" id=2]
-
-custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
-flip_faces = false
-radius = 1.0
-height = 2.0
-radial_segments = 64
-rings = 32
-is_hemisphere = false
+radial_segments = 9
+rings = 5
 
 [sub_resource type="Gradient" id=3]
-
-offsets = PoolRealArray( 0, 1 )
 colors = PoolColorArray( 1, 1, 1, 1, 1, 1, 1, 0 )
 
 [sub_resource type="GradientTexture" id=4]
-
-flags = 4
 gradient = SubResource( 3 )
-width = 2048
-_sections_unfolded = [ "gradient" ]
 
 [sub_resource type="Curve" id=5]
-
-min_value = 0.0
 max_value = 4.0
-bake_resolution = 100
 _data = [ Vector2( 0.150987, 4 ), 0.0, 0.0, 0, 0, Vector2( 1, 0.6936 ), 0.0, 0.0, 0, 0 ]
 
 [sub_resource type="CurveTexture" id=6]
-
-flags = 4
-width = 2048
 curve = SubResource( 5 )
-_sections_unfolded = [ "curve" ]
 
 [sub_resource type="ParticlesMaterial" id=7]
-
-render_priority = 0
-trail_divisor = 1
-emission_shape = 0
-flag_align_y = false
-flag_rotate_y = false
-flag_disable_z = false
 spread = 180.0
-flatness = 0.0
 gravity = Vector3( 0, -1, 0 )
 initial_velocity = 1.0
-initial_velocity_random = 0.0
-angular_velocity = 0.0
-angular_velocity_random = 0.0
-linear_accel = 0.0
-linear_accel_random = 0.0
-radial_accel = 0.0
-radial_accel_random = 0.0
-tangential_accel = 0.0
-tangential_accel_random = 0.0
-damping = 0.0
-damping_random = 0.0
-angle = 0.0
-angle_random = 0.0
 scale = 0.1
-scale_random = 0.0
 scale_curve = SubResource( 6 )
 color_ramp = SubResource( 4 )
-hue_variation = 0.0
-hue_variation_random = 0.0
-anim_speed = 0.0
-anim_speed_random = 0.0
-anim_offset = 0.0
-anim_offset_random = 0.0
-anim_loop = false
-_sections_unfolded = [ "Gravity", "Initial Velocity", "Scale", "Spread", "scale_curve" ]
 
 [sub_resource type="SpatialMaterial" id=8]
-
-render_priority = 0
 flags_transparent = true
-flags_unshaded = false
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
-flags_do_not_receive_shadows = false
-flags_disable_ambient_light = false
-flags_ensure_correct_normals = false
 vertex_color_use_as_albedo = true
 vertex_color_is_srgb = true
-params_diffuse_mode = 0
-params_specular_mode = 0
-params_blend_mode = 0
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
-params_billboard_mode = 0
-params_billboard_keep_scale = false
-params_grow = false
-params_use_alpha_scissor = false
-albedo_color = Color( 1, 1, 1, 1 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
 roughness = 0.0
-roughness_texture_channel = 0
 emission_enabled = true
 emission = Color( 0, 0.929412, 1, 1 )
 emission_energy = 2.0
 emission_operator = 0
 emission_on_uv2 = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_enable = false
-_sections_unfolded = [ "Emission", "Flags", "Vertex Color" ]
 
 [sub_resource type="SphereMesh" id=9]
-
 material = SubResource( 8 )
-custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
-flip_faces = false
 radius = 0.1
 height = 0.2
-radial_segments = 64
-rings = 32
-is_hemisphere = false
-_sections_unfolded = [ "material" ]
+radial_segments = 5
+rings = 3
 
 [sub_resource type="SphereShape" id=10]
-
 radius = 0.170413
 
 [sub_resource type="Gradient" id=11]
-
-offsets = PoolRealArray( 0, 1 )
-colors = PoolColorArray( 1, 1, 1, 0.961538, 0.960784, 0.960784, 0.960784, 0 )
+offsets = PoolRealArray( 0, 0.33, 1 )
+colors = PoolColorArray( 1, 1, 1, 1, 1, 1, 1, 0.133333, 1, 1, 1, 0 )
 
 [sub_resource type="GradientTexture" id=12]
-
-flags = 4
 gradient = SubResource( 11 )
-width = 2048
-_sections_unfolded = [ "gradient" ]
 
 [sub_resource type="Curve" id=13]
-
-min_value = 0.0
 max_value = 2.0
-bake_resolution = 100
 _data = [ Vector2( 0, 0.3856 ), 0.0, 0.0, 0, 0, Vector2( 0.0612366, 1 ), 0.0, 0.0, 0, 0, Vector2( 0.999703, 1.4752 ), 0.0, 0.0, 0, 0 ]
 
 [sub_resource type="CurveTexture" id=14]
-
-flags = 4
-width = 2048
 curve = SubResource( 13 )
 
 [sub_resource type="ParticlesMaterial" id=15]
-
-render_priority = 0
-trail_divisor = 1
-emission_shape = 0
-flag_align_y = false
-flag_rotate_y = false
-flag_disable_z = false
 spread = 180.0
-flatness = 0.0
 gravity = Vector3( 0, 0, 0 )
-initial_velocity = 0.3
-initial_velocity_random = 0.0
-angular_velocity = 35.2
+initial_velocity = 1.1
+angular_velocity = 360.0
 angular_velocity_random = 1.0
-linear_accel = 0.0
-linear_accel_random = 0.0
-radial_accel = 0.0
-radial_accel_random = 0.0
-tangential_accel = 0.0
-tangential_accel_random = 0.0
-damping = 0.0
-damping_random = 0.0
-angle = 0.0
-angle_random = 0.0
-scale = 4.0
-scale_random = 0.0
+scale = 0.8
 scale_curve = SubResource( 14 )
 color_ramp = SubResource( 12 )
-hue_variation = 0.0
-hue_variation_random = 0.0
-anim_speed = 0.0
-anim_speed_random = 0.0
-anim_offset = 0.0
-anim_offset_random = 0.0
-anim_loop = false
-_sections_unfolded = [ "Angular Velocity", "Gravity", "Initial Velocity", "Scale", "Spread", "scale_curve" ]
 
 [sub_resource type="SpatialMaterial" id=16]
-
-render_priority = 0
 flags_transparent = true
 flags_unshaded = true
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
-flags_do_not_receive_shadows = false
-flags_disable_ambient_light = false
-flags_ensure_correct_normals = false
 vertex_color_use_as_albedo = true
 vertex_color_is_srgb = true
-params_diffuse_mode = 0
-params_specular_mode = 0
 params_blend_mode = 1
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
 params_billboard_mode = 3
-params_billboard_keep_scale = false
-params_grow = false
-params_use_alpha_scissor = false
 particles_anim_h_frames = 1
 particles_anim_v_frames = 1
-particles_anim_loop = 0
-albedo_color = Color( 1, 1, 1, 1 )
+particles_anim_loop = false
 albedo_texture = ExtResource( 2 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
-roughness = 0.0
-roughness_texture_channel = 0
-emission_enabled = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
 proximity_fade_enable = true
-proximity_fade_distance = 0.2
-distance_fade_enable = false
-_sections_unfolded = [ "Albedo", "Distance Fade", "Flags", "Parameters", "Proximity Fade", "Vertex Color" ]
+proximity_fade_distance = 0.8
 
 [sub_resource type="QuadMesh" id=17]
-
 material = SubResource( 16 )
-custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
-flip_faces = false
-size = Vector2( 1, 1 )
-_sections_unfolded = [ "material" ]
 
 [sub_resource type="Animation" id=18]
-
 resource_name = "explode"
 length = 3.0
-loop = false
-step = 0.1
 tracks/0/type = "value"
 tracks/0/path = NodePath("explosion:emitting")
 tracks/0/interp = 1
@@ -359,7 +110,7 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.4 ),
+"times": PoolRealArray( 0, 0.5 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ true, false ]
@@ -371,7 +122,7 @@ tracks/1/loop_wrap = true
 tracks/1/imported = false
 tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0, 0.1, 0.5, 1.8 ),
+"times": PoolRealArray( 0, 0.1, 0.5, 1 ),
 "transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 0,
 "values": [ 1.5, 3.0, 1.5, 0.0 ]
@@ -383,7 +134,7 @@ tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 2.1 ),
+"times": PoolRealArray( 1.5 ),
 "transitions": PoolRealArray( 1 ),
 "values": [ {
 "args": [  ],
@@ -428,142 +179,45 @@ tracks/5/keys = {
 }
 
 [node name="bullet" type="KinematicBody"]
-input_ray_pickable = true
-input_capture_on_drag = false
-collision_layer = 1
-collision_mask = 1
-move_lock_x = false
-move_lock_y = false
-move_lock_z = false
-collision/safe_margin = 0.001
 script = ExtResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 transform = Transform( 0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0 )
-layers = 1
 material_override = SubResource( 1 )
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
+cast_shadow = 0
 mesh = SubResource( 2 )
-skeleton = NodePath("..")
 material/0 = null
-_sections_unfolded = [ "Geometry", "Transform", "Visibility", "material_override" ]
 
 [node name="Particles" type="Particles" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00988865, 0, 0 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
-emitting = true
 amount = 100
 lifetime = 0.3
-one_shot = false
-preprocess = 0.0
-speed_scale = 1.0
-explosiveness = 0.0
-randomness = 0.0
-fixed_fps = 0
-fract_delta = true
-visibility_aabb = AABB( -4, -4, -4, 8, 8, 8 )
 local_coords = false
-draw_order = 0
 process_material = SubResource( 7 )
-draw_passes = 1
 draw_pass_1 = SubResource( 9 )
-_sections_unfolded = [ "Draw Passes", "Drawing", "Geometry", "Process Material", "Time", "process_material" ]
 
 [node name="OmniLight" type="OmniLight" parent="."]
-layers = 1
 light_color = Color( 0, 1, 0.952941, 1 )
 light_energy = 1.5
-light_indirect_energy = 1.0
-light_negative = false
-light_specular = 0.5
-light_bake_mode = 1
-light_cull_mask = -1
+light_bake_mode = 0
 shadow_enabled = true
-shadow_color = Color( 0, 0, 0, 1 )
-shadow_bias = 0.15
-shadow_contact = 0.0
-shadow_reverse_cull_face = false
-editor_only = false
-omni_range = 9.30146
-omni_attenuation = 1.0
+omni_range = 3.0
+omni_attenuation = 2.0
 omni_shadow_mode = 0
-omni_shadow_detail = 1
-_sections_unfolded = [ "Light", "Omni", "Shadow" ]
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
 shape = SubResource( 10 )
-disabled = false
 
 [node name="explosion" type="Particles" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.452378, 0 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 emitting = false
-amount = 8
-lifetime = 1.0
-one_shot = false
-preprocess = 0.0
-speed_scale = 1.0
+amount = 6
 explosiveness = 1.0
-randomness = 0.0
-fixed_fps = 0
-fract_delta = true
-visibility_aabb = AABB( -4, -4, -4, 8, 8, 8 )
-local_coords = true
-draw_order = 0
 process_material = SubResource( 15 )
-draw_passes = 1
 draw_pass_1 = SubResource( 17 )
-_sections_unfolded = [ "Draw Passes", "Process Material", "draw_pass_1", "process_material" ]
 
 [node name="anim" type="AnimationPlayer" parent="."]
-root_node = NodePath("..")
-autoplay = ""
-playback_process_mode = 1
-playback_default_blend_time = 0.0
-playback_speed = 1.0
 anims/explode = SubResource( 18 )
-blend_times = [  ]
-_sections_unfolded = [ "Playback Options" ]
 
 [node name="explosion2" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 3 )
-attenuation_model = 0
-unit_db = 0.0
 unit_size = 20.0
-max_db = 3.0
-pitch_scale = 1.0
-autoplay = false
-stream_paused = false
-max_distance = 0.0
-out_of_range_mode = 0
-bus = "Master"
-area_mask = 1
-emission_angle_enabled = false
-emission_angle_degrees = 45.0
-emission_angle_filter_attenuation_db = -12.0
-attenuation_filter_cutoff_hz = 5000.0
-attenuation_filter_db = -24.0
-doppler_tracking = 0
-


### PR DESCRIPTION
- Don't bake GI for bullet lights to improve performance and avoid flickering
- Use less detailed spheres for the main bullet and its trail
- Use smaller lights to be more subtle, also making shadow acne less visible
- Tweak the explosion effect to be more subtle