### PR TITLE
Update scripts to conform to the GDScript style guide

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -29,4 +29,3 @@ bus/2/volume_db = 0.0
 bus/2/send = "Master"
 bus/2/effect/0/effect = SubResource( 2 )
 bus/2/effect/0/enabled = true
-

--- a/default_env.tres
+++ b/default_env.tres
@@ -12,4 +12,3 @@ sun_energy = 16.0
 [resource]
 background_mode = 2
 background_sky = SubResource( 1 )
-

--- a/door/door.gd
+++ b/door/door.gd
@@ -1,21 +1,8 @@
 extends Area
 
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
 var open = false
-func _ready():
-	# Called when the node is added to the scene for the first time.
-	# Initialization here.
-	pass
-
-#func _process(delta):
-#	# Called every frame. Delta is time since last frame.
-#	# Update game logic here.
-#	pass
-
 
 func _on_door_body_entered(body):
-	if (not open and body is preload("res://player/player.gd")):
+	if not open and body is preload("res://player/player.gd"):
 		$"Scene Root/AnimationPlayer".play("doorsimple_opening")
 		open = true

--- a/enemies/red_robot/red_robot.gd
+++ b/enemies/red_robot/red_robot.gd
@@ -1,222 +1,200 @@
 extends KinematicBody
 
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
-
-const GRAVITY = Vector3(0,-9.8, 0)
+enum State {
+	APPROACH = 0,
+	AIM = 1,
+	SHOOTING = 2,
+}
 
 const PLAYER_AIM_TOLERANCE_DEGREES = 15
 
-const STATE_APPROACH = 0
-const STATE_AIM = 1
-const STATE_SHOOTING = 2
-
-var state = STATE_APPROACH
-
 const SHOOT_WAIT = 6.0
-var shoot_countdown = SHOOT_WAIT
 const AIM_TIME = 1
-var aim_countdown = AIM_TIME
 
 const AIM_PREPARE_TIME = 0.5
+const BLEND_AIM_SPEED = 0.05
+
+var state = State.APPROACH
+
+var shoot_countdown = SHOOT_WAIT
+var aim_countdown = AIM_TIME
 var aim_preparing = AIM_PREPARE_TIME
+var energy = 5
+var dead = false
+var test_shoot = false
 
 var player = null
 var velocity = Vector3()
-
 var orientation = Transform()
 
-const MAX_ENERGY = 5
-
-var energy = MAX_ENERGY
-
-
-const BLEND_AIM_SPEED = 0.05
+onready var gravity = ProjectSettings.get_setting("physics/3d/default_gravity") * ProjectSettings.get_setting("physics/3d/default_gravity_vector")
 
 func _ready():
-	orientation=$"Scene Root".global_transform
+	orientation = global_transform
 	orientation.origin = Vector3()
-	
+
+
 func resume_approach():
-	state = STATE_APPROACH
+	state = State.APPROACH
 	aim_preparing = AIM_PREPARE_TIME
 	shoot_countdown = SHOOT_WAIT
-	
-var dead = false
-	
+
+
 func hit():
-	if (dead):
+	if dead:
 		return
-	$AnimationTree["parameters/hit"+["1","2","3"][randi()%3]+"/active"]=true
+	$AnimationTree["parameters/hit" + ["1", "2", "3"][randi() % 3] + "/active"] = true
 	$sfx/hit.play()
-	energy-=1
-	if (energy==0):
-		dead=true
+	energy -= 1
+	if energy == 0:
+		dead = true
 		var base_xf = global_transform.basis
-		$AnimationTree.active=false
+		$AnimationTree.active = false
 		#$death/explosion.play("kaboom")
-		$"Scene Root".visible=false
-		$death.visible=true
-		$CollisionShape.disabled=true
-		$death/particles.emitting=true
-		$death/part_shield1/col1.disabled=false
-		$death/part_shield1/col2.disabled=false
-		$death/part_shield1.mode=RigidBody.MODE_RIGID
-		$death/part_shield2/col1.disabled=false
-		$death/part_shield2/col2.disabled=false
-		$death/part_shield2.mode=RigidBody.MODE_RIGID
-		$death/part_shield3/col1.disabled=false
-		$death/part_shield3/col2.disabled=false		
-		$death/part_shield3.mode=RigidBody.MODE_RIGID
-		$death/part_shield2.linear_velocity = (base_xf.x+Vector3(0,1,0)).normalized() * 3
-		$death/part_shield3.linear_velocity = (Vector3(0,1,0)).normalized() * 3
-		$death/part_shield1.linear_velocity = (-base_xf.x+Vector3(0,1,0)).normalized() * 3
-		$death/part_shield2.angular_velocity = (Vector3(randf(),randf(),randf()).normalized() * Vector3(2,2,2) - Vector3(1,1,1)) * 10
-		$death/part_shield1.angular_velocity = (Vector3(randf(),randf(),randf()).normalized() * Vector3(2,2,2) - Vector3(1,1,1)) * 10
-		$death/part_shield3.angular_velocity = (Vector3(randf(),randf(),randf()).normalized() * Vector3(2,2,2) - Vector3(1,1,1)) * 10
+		$"Scene Root".visible = false
+		$death.visible = true
+		$CollisionShape.disabled = true
+		$death/particles.emitting = true
+		
+		$death/part_shield1/col1.disabled = false
+		$death/part_shield1/col2.disabled = false
+		$death/part_shield1.mode = RigidBody.MODE_RIGID
+		$death/part_shield2/col1.disabled = false
+		$death/part_shield2/col2.disabled = false
+		$death/part_shield2.mode = RigidBody.MODE_RIGID
+		$death/part_shield3/col1.disabled = false
+		$death/part_shield3/col2.disabled = false
+		$death/part_shield3.mode = RigidBody.MODE_RIGID
+		
+		$death/part_shield2.linear_velocity = 3 * (Vector3.UP + base_xf.x).normalized()
+		$death/part_shield3.linear_velocity = 3 * (Vector3.UP).normalized()
+		$death/part_shield1.linear_velocity = 3 * (Vector3.UP - base_xf.x).normalized()
+		$death/part_shield2.angular_velocity = (Vector3(randf(), randf(), randf()).normalized() * 2 - Vector3.ONE) * 10
+		$death/part_shield1.angular_velocity = (Vector3(randf(), randf(), randf()).normalized() * 2 - Vector3.ONE) * 10
+		$death/part_shield3.angular_velocity = (Vector3(randf(), randf(), randf()).normalized() * 2 - Vector3.ONE) * 10
 		$sfx/explosion.play()
 
 
-func do_shoot():
+func shoot():
 	var gt = $"Scene Root/Armature/Skeleton/ray_from".global_transform
 	var ray_from = gt.origin
 	var ray_dir = -gt.basis.z
 	var max_dist = 1000
 	
-	var col = get_world().direct_space_state.intersect_ray(ray_from,ray_from + ray_dir * max_dist,[self])
-	if (not col.empty()):
+	var col = get_world().direct_space_state.intersect_ray(ray_from, ray_from + ray_dir * max_dist, [self])
+	if not col.empty():
 		max_dist = ray_from.distance_to(col.position)
-		if (col.collider == player):
-			pass # kill
-	#clip ray in shader
-	$"Scene Root/Armature/Skeleton/ray_from/ray".get_surface_material(0).set_shader_param("clip",max_dist)
-	#position explosion			
+		if col.collider == player:
+			pass # Kill.
+	# Clip ray in shader.
+	$"Scene Root/Armature/Skeleton/ray_from/ray".get_surface_material(0).set_shader_param("clip", max_dist)
+	# Position explosion.
 	$"Scene Root/Armature/Skeleton/ray_from/explosion".transform.origin.z = -max_dist
-	
-var test_shoot=false
-func shoot_check():
-	test_shoot=true
-	
+
+
 func _physics_process(delta):
 	if (test_shoot):
-		do_shoot()
-		test_shoot=false
-		
-	if (dead):
+		shoot()
+		test_shoot = false
+	
+	if dead:
 		return
-		
-	if (not player):
-		$AnimationTree["parameters/state/current"]=0 # go idle and good bye
+	
+	if not player:
+		$AnimationTree["parameters/state/current"] = 0 # Go idle.
 		return
-	var to_player_local = $"Scene Root".global_transform.affine_inverse().xform(player.global_transform.origin)
-	var to_player_angle = atan2( to_player_local.x, to_player_local.z )
-		
-	if (state == STATE_APPROACH):
-		
-		
+	
+	if (state == State.APPROACH):
 		if (aim_preparing > 0):
-			aim_preparing-=delta
-			if (aim_preparing<0):
-				aim_preparing=0
-			$AnimationTree["parameters/aiming/blend_amount"]= aim_preparing / AIM_PREPARE_TIME
-
+			aim_preparing -= delta
+			if (aim_preparing < 0):
+				aim_preparing = 0
+			$AnimationTree["parameters/aiming/blend_amount"] = aim_preparing / AIM_PREPARE_TIME
 		
-		if (to_player_angle < -deg2rad(PLAYER_AIM_TOLERANCE_DEGREES)):
-			$AnimationTree["parameters/state/current"]=2
-		elif (to_player_angle > deg2rad(PLAYER_AIM_TOLERANCE_DEGREES)):
-			$AnimationTree["parameters/state/current"]=1
+		var to_player_local = global_transform.xform_inv(player.global_transform.origin)
+		# The front of the robot is +Z, and atan2 is zero at +X, so we need to use the Z for the X parameter (second one).
+		var angle_to_player = atan2(to_player_local.x, to_player_local.z)
+		var tolerance = deg2rad(PLAYER_AIM_TOLERANCE_DEGREES)
+		if (angle_to_player > tolerance):
+			$AnimationTree["parameters/state/current"] = 1
+		elif (angle_to_player < -tolerance):
+			$AnimationTree["parameters/state/current"] = 2
 		else:
-			$AnimationTree["parameters/state/current"]=3
-			# facing player, try to shoot		
-			shoot_countdown-=delta
-			if (shoot_countdown <0):
-				#see if player can be killed because in sight		
+			$AnimationTree["parameters/state/current"] = 3
+			# Facing player, try to shoot.
+			shoot_countdown -= delta
+			if (shoot_countdown < 0):
+				# See if player can be killed because in they're sight.
 				var ray_from = $"Scene Root/Armature/Skeleton/ray_from".global_transform.origin
-				var ray_to = player.global_transform.origin + Vector3(0,1,0) # middle of player
-				var col = get_world().direct_space_state.intersect_ray(ray_from,ray_to,[self])
-				if (not col.empty() and col.collider == player):					
-					state = STATE_AIM
+				var ray_to = player.global_transform.origin + Vector3.UP # Above middle of player.
+				var col = get_world().direct_space_state.intersect_ray(ray_from, ray_to, [self])
+				if not col.empty() and col.collider == player:
+					state = State.AIM
 					aim_countdown = AIM_TIME
 					aim_preparing = 0
-					$AnimationTree["parameters/state/current"]=0
-
+					$AnimationTree["parameters/state/current"] = 0
 				else:
-					#player not in sight, do nothing
+					# Player not in sight, do nothing.
 					shoot_countdown = SHOOT_WAIT
-			
-	elif (state==STATE_AIM or state==STATE_SHOOTING):
-		
-			
-			if (aim_preparing<AIM_PREPARE_TIME):
-				aim_preparing+=delta
+	
+	elif state == State.AIM or state == State.SHOOTING:
+			if (aim_preparing < AIM_PREPARE_TIME):
+				aim_preparing += delta
 				if (aim_preparing > AIM_PREPARE_TIME):
 					aim_preparing = AIM_PREPARE_TIME
-					
-			$AnimationTree["parameters/aiming/blend_amount"]=clamp(aim_preparing / AIM_PREPARE_TIME,0,1)
-		
-			aim_countdown-=delta
-			if (aim_countdown<0 and state==STATE_AIM):
-				
+			
+			$AnimationTree["parameters/aiming/blend_amount"] = clamp(aim_preparing / AIM_PREPARE_TIME, 0, 1)
+			aim_countdown -= delta
+			if aim_countdown < 0 and state == State.AIM:
 				var ray_from = $"Scene Root/Armature/Skeleton/ray_from".global_transform.origin
-				var ray_to = player.global_transform.origin + Vector3(0,1,0) # middle of player
-				var col = get_world().direct_space_state.intersect_ray(ray_from,ray_to,[self])
-				if (not col.empty() and col.collider == player):
-					state = STATE_SHOOTING
+				var ray_to = player.global_transform.origin + Vector3.UP # Above middle of player.
+				var col = get_world().direct_space_state.intersect_ray(ray_from, ray_to, [self])
+				if not col.empty() and col.collider == player:
+					state = State.SHOOTING
 					$shoot_anim.play("shoot")
 				else:
 					resume_approach()
-	
-			if ($AnimationTree.active):
-				
-				var to_cannon_local = $"Scene Root/Armature/Skeleton/ray_from/ray".global_transform.affine_inverse().xform(player.global_transform.origin + Vector3(0,1,0))
+			
+			if $AnimationTree.active:
+				var to_cannon_local = $"Scene Root/Armature/Skeleton/ray_from/ray".global_transform.xform_inv(player.global_transform.origin + Vector3.UP)
 				var h_angle = rad2deg(atan2( to_cannon_local.x, -to_cannon_local.z ))
 				var v_angle = rad2deg(atan2( to_cannon_local.y, -to_cannon_local.z ))
-	
-
 				var blend_pos = $AnimationTree["parameters/aim/blend_position"]
 				var h_motion = BLEND_AIM_SPEED * delta * -h_angle
 				blend_pos.x += h_motion
-				blend_pos.x = clamp(blend_pos.x, -1 , 1 )
+				blend_pos.x = clamp(blend_pos.x, -1, 1)
 				
 				var v_motion = BLEND_AIM_SPEED * delta * v_angle
 				blend_pos.y += v_motion
-				blend_pos.y = clamp(blend_pos.y, -1 , 1 )
+				blend_pos.y = clamp(blend_pos.y, -1, 1)
 					
-				$AnimationTree["parameters/aim/blend_position"]= blend_pos
-
-				
-			
-
-			
-	var root_motion = $AnimationTree.get_root_motion_transform()
-		
-		
-	# apply root motion to orientation
-	orientation *= root_motion
+				$AnimationTree["parameters/aim/blend_position"] = blend_pos
+	
+	# Apply root motion to orientation.
+	orientation *= $AnimationTree.get_root_motion_transform()
 	
 	var h_velocity = orientation.origin / delta
 	velocity.x = h_velocity.x
-	velocity.z = h_velocity.z		
-	velocity += GRAVITY * delta
-	velocity = move_and_slide(velocity,Vector3(0,1,0))
-
-	orientation.origin = Vector3() #clear accumulated root motion displacement (was applied to speed)
-	orientation = orientation.orthonormalized() # orthonormalize orientation
+	velocity.z = h_velocity.z
+	velocity += gravity * delta
+	velocity = move_and_slide(velocity, Vector3.UP)
 	
-	$"Scene Root".global_transform.basis = orientation.basis
-
-
-		
+	orientation.origin = Vector3() # Clear accumulated root motion displacement (was applied to speed).
+	orientation = orientation.orthonormalized() # orthonormalize orientation.
 	
-			
+	global_transform.basis = orientation.basis
+
+
+func shoot_check():
+	test_shoot = true
+
 
 func _on_area_body_entered(body):
-	if (body is preload("res://player/player.gd")):
+	if body is preload("res://player/player.gd"):
 		player = body
-		shoot_countdown=SHOOT_WAIT
+		shoot_countdown = SHOOT_WAIT
 
 
 func _on_area_body_exited(body):
-	if (body is preload("res://player/player.gd")):
+	if body is preload("res://player/player.gd"):
 		player = null

--- a/level/level.gd
+++ b/level/level.gd
@@ -1,47 +1,38 @@
 extends Spatial
 
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
-
 func _ready():
-	if (settings.gi_quality == settings.GI_QUALITY_HIGH):
-		ProjectSettings["rendering/quality/voxel_cone_tracing/high_quality"]=true
-	elif (settings.gi_quality == settings.GI_QUALITY_LOW):
-		ProjectSettings["rendering/quality/voxel_cone_tracing/high_quality"]=false
+	if settings.gi_quality == settings.GIQuality.HIGH:
+		ProjectSettings["rendering/quality/voxel_cone_tracing/high_quality"] = true
+	elif settings.gi_quality == settings.GIQuality.LOW:
+		ProjectSettings["rendering/quality/voxel_cone_tracing/high_quality"] = false
 	else:
 		$GIProbe.hide()
 		$refprobes.show()
-		
-	if (settings.aa_quality == settings.AA_8X):
+	
+	if settings.aa_quality == settings.AAQuality.AA_8X:
 		get_node("/root").msaa = Viewport.MSAA_8X
-	elif (settings.aa_quality == settings.AA_4X):
+	elif settings.aa_quality == settings.AAQuality.AA_4X:
 		get_node("/root").msaa = Viewport.MSAA_4X
-	elif (settings.aa_quality == settings.AA_2X):
+	elif settings.aa_quality == settings.AAQuality.AA_2X:
 		get_node("/root").msaa = Viewport.MSAA_2X
 	else:
 		get_node("/root").msaa = Viewport.MSAA_DISABLED
-		
-	if (settings.ssao_quality == settings.SSAO_QUALITY_HIGH):
+	
+	if settings.ssao_quality == settings.SSAOQuality.HIGH:
 		$WorldEnvironment.environment.ssao_quality = $WorldEnvironment.environment.SSAO_QUALITY_HIGH
-	elif (settings.ssao_quality == settings.SSAO_QUALITY_LOW):
+	elif settings.ssao_quality == settings.SSAOQuality.LOW:
 		$WorldEnvironment.environment.ssao_quality = $WorldEnvironment.environment.SSAO_QUALITY_LOW
 	else:
 		$WorldEnvironment.environment.ssao_enabled = false
-		
-	if (settings.resolution == settings.RESOLUTION_NATIVE):
+	
+	if settings.resolution == settings.Resolution.NATIVE:
 		pass
-	elif (settings.resolution == settings.RESOLUTION_1080):
-		var minsize=Vector2( OS.window_size.x * 1080 / OS.window_size.y, 1080.0)
+	elif settings.resolution == settings.Resolution.RES_1080:
+		var minsize = Vector2(OS.window_size.x * 1080 / OS.window_size.y, 1080.0)
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT,SceneTree.STRETCH_ASPECT_KEEP_HEIGHT,minsize)
-	elif (settings.resolution == settings.RESOLUTION_720):
-		var minsize=Vector2( OS.window_size.x * 720 / OS.window_size.y, 720.0)
+	elif settings.resolution == settings.Resolution.RES_720:
+		var minsize = Vector2(OS.window_size.x * 720 / OS.window_size.y, 720.0)
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT,SceneTree.STRETCH_ASPECT_KEEP_HEIGHT,minsize)
-	elif (settings.resolution == settings.RESOLUTION_576):
-		var minsize=Vector2( OS.window_size.x * 576 / OS.window_size.y, 576.0)
+	elif settings.resolution == settings.Resolution.RES_576:
+		var minsize = Vector2(OS.window_size.x * 576 / OS.window_size.y, 576.0)
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT,SceneTree.STRETCH_ASPECT_KEEP_HEIGHT,minsize)
-		
-#func _process(delta):
-#	# Called every frame. Delta is time since last frame.
-#	# Update game logic here.
-#	pass

--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -1,53 +1,45 @@
 extends Spatial
 
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
-
-func _ready():
-	pass
-
 func _on_play_pressed():
 	$ui/main.hide()
 	$ui/loading.show()
 	$begin_load_timer.start()
 
 
-
 func _on_settings_pressed():
 	$ui/main.hide()
 	$ui/settings.show()
 	
-	if (settings.gi_quality == settings.GI_QUALITY_HIGH):
+	if settings.gi_quality == settings.GIQuality.HIGH:
 		$ui/settings/gi_high.pressed=true
-	elif (settings.gi_quality == settings.GI_QUALITY_LOW):
+	elif settings.gi_quality == settings.GIQuality.LOW:
 		$ui/settings/gi_low.pressed=true
-	elif (settings.gi_quality == settings.GI_QUALITY_DISABLED):
+	elif settings.gi_quality == settings.GIQuality.DISABLED:
 		$ui/settings/gi_disabled.pressed=true
 
-	if (settings.aa_quality == settings.AA_8X):
+	if settings.aa_quality == settings.AAQuality.AA_8X:
 		$ui/settings/aa_8x.pressed=true
-	elif (settings.aa_quality == settings.AA_4X):
+	elif settings.aa_quality == settings.AAQuality.AA_4X:
 		$ui/settings/aa_4x.pressed=true
-	elif (settings.aa_quality == settings.AA_2X):
+	elif settings.aa_quality == settings.AAQuality.AA_2X:
 		$ui/settings/aa_2x.pressed=true
-	elif (settings.aa_quality == settings.AA_DISABLED):
+	elif settings.aa_quality == settings.AAQuality.AA_DISABLED:
 		$ui/settings/aa_disabled.pressed=true
 
-	if (settings.ssao_quality == settings.SSAO_QUALITY_HIGH):
+	if settings.ssao_quality == settings.SSAOQuality.HIGH:
 		$ui/settings/ssao_high.pressed=true
-	elif (settings.ssao_quality == settings.SSAO_QUALITY_LOW):
+	elif settings.ssao_quality == settings.SSAOQuality.LOW:
 		$ui/settings/ssao_low.pressed=true
-	elif (settings.ssao_quality == settings.SSAO_QUALITY_DISABLED):
+	elif settings.ssao_quality == settings.SSAOQuality.DISABLED:
 		$ui/settings/ssao_disabled.pressed=true
 		
-	if (settings.resolution == settings.RESOLUTION_NATIVE):
+	if settings.resolution == settings.Resolution.NATIVE:
 		$ui/settings/resolution_native.pressed = true
-	elif (settings.resolution == settings.RESOLUTION_1080):
+	elif settings.resolution == settings.Resolution.RES_1080:
 		$ui/settings/resolution_1080.pressed = true
-	elif (settings.resolution == settings.RESOLUTION_720):
+	elif settings.resolution == settings.Resolution.RES_720:
 		$ui/settings/resolution_720.pressed = true
-	elif (settings.resolution == settings.RESOLUTION_576):
+	elif settings.resolution == settings.Resolution.RES_576:
 		$ui/settings/resolution_576.pressed = true
 
 
@@ -59,39 +51,40 @@ func _on_apply_pressed():
 	$ui/main.show()
 	$ui/settings.hide()
 	
-	if($ui/settings/gi_high.pressed):
-		settings.gi_quality = settings.GI_QUALITY_HIGH
-	elif($ui/settings/gi_low.pressed):
-		settings.gi_quality = settings.GI_QUALITY_LOW
-	elif($ui/settings/gi_disabled.pressed):
-		settings.gi_quality = settings.GI_QUALITY_DISABLED
-
-	if($ui/settings/aa_8x.pressed):
-		settings.aa_quality = settings.AA_8X
-	elif($ui/settings/aa_4x.pressed):
-		settings.aa_quality = settings.AA_4X
-	elif($ui/settings/aa_2x.pressed):
-		settings.aa_quality = settings.AA_2X
-	elif($ui/settings/aa_disabled.pressed):
-		settings.aa_quality = settings.AA_DISABLED
-
-	if($ui/settings/ssao_high.pressed):
-		settings.ssao_quality = settings.SSAO_QUALITY_HIGH
-	elif($ui/settings/ssao_low.pressed):
-		settings.ssao_quality = settings.SSAO_QUALITY_LOW
-	elif($ui/settings/ssao_disabled.pressed):
-		settings.ssao_quality = settings.SSAO_QUALITY_DISABLED
-
-	if($ui/settings/resolution_native.pressed):
-		settings.resolution = settings.RESOLUTION_NATIVE
-	elif($ui/settings/resolution_1080.pressed):
-		settings.resolution = settings.RESOLUTION_1080
-	elif($ui/settings/resolution_720.pressed):
-		settings.resolution = settings.RESOLUTION_720
-	elif($ui/settings/resolution_576.pressed):
-		settings.resolution = settings.RESOLUTION_576
-
+	if $ui/settings/gi_high.pressed:
+		settings.gi_quality = settings.GIQuality.HIGH
+	elif $ui/settings/gi_low.pressed:
+		settings.gi_quality = settings.GIQuality.LOW
+	elif $ui/settings/gi_disabled.pressed:
+		settings.gi_quality = settings.GIQuality.DISABLED
+	
+	if $ui/settings/aa_8x.pressed:
+		settings.aa_quality = settings.AAQuality.AA_8X
+	elif $ui/settings/aa_4x.pressed:
+		settings.aa_quality = settings.AAQuality.AA_4X
+	elif $ui/settings/aa_2x.pressed:
+		settings.aa_quality = settings.AAQuality.AA_2X
+	elif $ui/settings/aa_disabled.pressed:
+		settings.aa_quality = settings.AAQuality.AA_DISABLED
+	
+	if $ui/settings/ssao_high.pressed:
+		settings.ssao_quality = settings.SSAOQuality.HIGH
+	elif $ui/settings/ssao_low.pressed:
+		settings.ssao_quality = settings.SSAOQuality.LOW
+	elif $ui/settings/ssao_disabled.pressed:
+		settings.ssao_quality = settings.SSAOQuality.DISABLED
+	
+	if $ui/settings/resolution_native.pressed:
+		settings.resolution = settings.Resolution.NATIVE
+	elif $ui/settings/resolution_1080.pressed:
+		settings.resolution = settings.Resolution.RES_1080
+	elif $ui/settings/resolution_720.pressed:
+		settings.resolution = settings.Resolution.RES_720
+	elif $ui/settings/resolution_576.pressed:
+		settings.resolution = settings.Resolution.RES_576
+	
 	settings.save_settings()
+
 
 func _on_cancel_pressed():
 	$ui/main.show()
@@ -99,4 +92,5 @@ func _on_cancel_pressed():
 
 
 func _on_begin_load_timer_timeout():
+	#warning-ignore:return_value_discarded
 	get_tree().change_scene("res://level/level.tscn")

--- a/menu/menu.tscn
+++ b/menu/menu.tscn
@@ -617,7 +617,6 @@ text = "Loading..."
 
 [node name="begin_load_timer" type="Timer" parent="."]
 wait_time = 0.2
-
 [connection signal="pressed" from="ui/main/play" to="." method="_on_play_pressed"]
 [connection signal="pressed" from="ui/main/settings" to="." method="_on_settings_pressed"]
 [connection signal="pressed" from="ui/main/quit" to="." method="_on_quit_pressed"]

--- a/menu/settings.gd
+++ b/menu/settings.gd
@@ -1,69 +1,68 @@
 extends Node
 
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
+enum GIQuality {
+	DISABLED = 0
+	LOW = 1
+	HIGH = 2
+}
 
-const GI_QUALITY_HIGH = 2	
-const GI_QUALITY_LOW = 1	
-const GI_QUALITY_DISABLED = 0
+enum AAQuality {
+	DISABLED = 0
+	AA_2X = 1
+	AA_4X = 2
+	AA_8X = 3
+}
 
-const AA_8X = 3
-const AA_4X = 2
-const AA_2X = 1
-const AA_DISABLED = 0
+enum SSAOQuality {
+	DISABLED = 0
+	LOW = 1
+	HIGH = 2
+}
 
-const SSAO_QUALITY_HIGH = 2	
-const SSAO_QUALITY_LOW = 1	
-const SSAO_QUALITY_DISABLED = 0
+enum Resolution {
+	RES_576 = 0
+	RES_720 = 1
+	RES_1080 = 2
+	NATIVE = 3
+}
 
-const RESOLUTION_NATIVE = 3
-const RESOLUTION_1080 = 2
-const RESOLUTION_720 = 1
-const RESOLUTION_576 = 0
+var gi_quality = GIQuality.LOW
+var aa_quality = AAQuality.AA_2X
+var ssao_quality = SSAOQuality.DISABLED
+var resolution = Resolution.NATIVE
 
-var gi_quality = GI_QUALITY_LOW
-var aa_quality = AA_2X
-var ssao_quality = SSAO_QUALITY_DISABLED
-var resolution = RESOLUTION_NATIVE
-
-func load_settings():
-	var f = File.new()
-	var error = f.open("user://settings.json", File.READ)
-	if (error):
-		print("no settings to load..")
-		return
-	var d = parse_json( f.get_as_text() )
-	if (typeof(d)!=TYPE_DICTIONARY):
-		return
-	if ("gi" in d):	
-		gi_quality = int(d.gi)
-		
-	if ("aa" in d):	
-		aa_quality = int(d.aa)
-		
-	if ("ssao" in d):
-		ssao_quality = int(d.ssao)
-
-	if ("resolution" in d):
-		resolution = int(d.resolution)
-	
-func save_settings():
-	
-	var f = File.new()
-	var error = f.open("user://settings.json", File.WRITE)
-	assert( not error )
-	
-	var d = { "gi":gi_quality, "aa":aa_quality, "ssao":ssao_quality, "resolution":resolution }
-	f.store_line( to_json(d) )
-
-
-	
 func _ready():
 	load_settings()
 
 
-#func _process(delta):
-#	# Called every frame. Delta is time since last frame.
-#	# Update game logic here.
-#	pass
+func load_settings():
+	var f = File.new()
+	var error = f.open("user://settings.json", File.READ)
+	if error:
+		print("There are no settings to load.")
+		return
+	
+	var d = parse_json(f.get_as_text())
+	if typeof(d) != TYPE_DICTIONARY:
+		return
+	
+	if "gi" in d:
+		gi_quality = int(d.gi)
+	
+	if "aa" in d:
+		aa_quality = int(d.aa)
+	
+	if "ssao" in d:
+		ssao_quality = int(d.ssao)
+	
+	if "resolution" in d:
+		resolution = int(d.resolution)
+
+
+func save_settings():
+	var f = File.new()
+	var error = f.open("user://settings.json", File.WRITE)
+	assert(not error)
+	
+	var d = { "gi":gi_quality, "aa":aa_quality, "ssao":ssao_quality, "resolution":resolution }
+	f.store_line(to_json(d))

--- a/player/bullet.gd
+++ b/player/bullet.gd
@@ -1,42 +1,26 @@
 extends KinematicBody
 
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
-
-var time_alive=5
-var direction = Vector3()
-
 const BULLET_VELOCITY = 20
-var hit=false
+
+var time_alive = 5
+var direction = Vector3()
+var hit = false
 
 func _process(delta):
-	if (hit):
+	if hit:
 		return
-		
-	time_alive-=delta
-	if (time_alive<0):
-		hit=true
+	
+	time_alive -= delta
+	if time_alive < 0:
+		hit = true
 		$anim.play("explode")
 	var col = move_and_collide(delta * direction * BULLET_VELOCITY)
-	if (col):
-		if (col.collider and col.collider.has_method("hit")):
+	if col:
+		if col.collider and col.collider.has_method("hit"):
 			col.collider.hit()
-		$CollisionShape.disabled=true
+		$CollisionShape.disabled = true
 		$anim.play("explode")
-		hit=true
-	
-
-
-func _ready():
-	# Called when the node is added to the scene for the first time.
-	# Initialization here.
-	pass
-
-#func _process(delta):
-#	# Called every frame. Delta is time since last frame.
-#	# Update game logic here.
-#	pass
+		hit = true
 
 
 func _on_bullet_body_entered():

--- a/player/player.gd
+++ b/player/player.gd
@@ -1,185 +1,164 @@
 extends KinematicBody
 
-
-var aiming = false
 const CAMERA_ROTATION_SPEED = 0.001
-const GRAVITY = Vector3(0,-9.8, 0)
-const DIRECTION_INTERPOLATE_SPEED = 1
-
-const MOTION_INTERPOLATE_SPEED = 10
-const ROTATION_INTERPOLATE_SPEED = 10
-var motion = Vector2()
-
 const CAMERA_X_ROT_MIN = -40
 const CAMERA_X_ROT_MAX = 30
 
-var camera_x_rot = 0.0
+const DIRECTION_INTERPOLATE_SPEED = 1
+const MOTION_INTERPOLATE_SPEED = 10
+const ROTATION_INTERPOLATE_SPEED = 10
 
-var velocity = Vector3()
-
-var orientation = Transform()
-
-var airborne_time = 100
 const MIN_AIRBORNE_TIME = 0.1
-
 const JUMP_SPEED = 5
 
+var airborne_time = 100
+
+var orientation = Transform()
 var root_motion = Transform()
+var motion = Vector2()
+var velocity = Vector3()
 
-func _input(event):
-	if event is InputEventMouseMotion:
-		$camera_base.rotate_y( -event.relative.x * CAMERA_ROTATION_SPEED )
-		$camera_base.orthonormalize() # after relative transforms, camera needs to be renormalized
-		camera_x_rot = clamp(camera_x_rot + event.relative.y * CAMERA_ROTATION_SPEED,deg2rad(CAMERA_X_ROT_MIN), deg2rad(CAMERA_X_ROT_MAX) )
-		$camera_base/camera_rot.rotation.x =  camera_x_rot
+var aiming = false
+var camera_x_rot = 0.0
 
-	if event.is_action_pressed("quit"):
-		get_tree().quit()
+onready var gravity = ProjectSettings.get_setting("physics/3d/default_gravity") * ProjectSettings.get_setting("physics/3d/default_gravity_vector")
+
+func _init():
+	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+
 
 func _ready():
-	#pre initialize orientation transform	
-	orientation=$"Scene Root".global_transform
+	# Pre-initialize orientation transform.
+	orientation = $"Scene Root".global_transform
 	orientation.origin = Vector3()
-#	$camera_base/camera_rot/Camera.add_exception(self)
-	
+
+
 func _physics_process(delta):
-	
-	var motion_target = Vector2( 	Input.get_action_strength("move_right") - Input.get_action_strength("move_left"),
-									Input.get_action_strength("move_forward") - Input.get_action_strength("move_back") )
-			
+	var motion_target = Vector2(Input.get_action_strength("move_right") - Input.get_action_strength("move_left"), 
+								Input.get_action_strength("move_forward") - Input.get_action_strength("move_back"))
 	motion = motion.linear_interpolate(motion_target, MOTION_INTERPOLATE_SPEED * delta)
 	
-	var cam_z = - $camera_base/camera_rot/Camera.global_transform.basis.z			
-	var cam_x = $camera_base/camera_rot/Camera.global_transform.basis.x
+	var camera_basis = $camera_base/camera_rot/Camera.global_transform.basis
+	var camera_z = camera_basis.z
+	var camera_x = camera_basis.x
 	
-	cam_z.y=0
-	cam_z = cam_z.normalized()
-	cam_x.y=0
-	cam_x = cam_x.normalized()
+	camera_z.y = 0
+	camera_z = camera_z.normalized()
+	camera_x.y = 0
+	camera_x = camera_x.normalized()
 	
 	var current_aim = Input.is_action_pressed("aim")
 	
-	if (aiming != current_aim):
+	if aiming != current_aim:
 			aiming = current_aim
 			if (aiming):
 				$camera_base/animation.play("shoot")
 			else:
 				$camera_base/animation.play("far")
 	
-	# jump/air logic
+	# Jump/in-air logic.
 	airborne_time += delta
-	if (is_on_floor()):
-		if (airborne_time>0.5):
+	if is_on_floor():
+		if airborne_time > 0.5:
 			$sfx/land.play()
 		airborne_time = 0
-		
+	
 	var on_air = airborne_time > MIN_AIRBORNE_TIME
 	
-	if (not on_air and Input.is_action_just_pressed("jump")):
+	if not on_air and Input.is_action_just_pressed("jump"):
 		velocity.y = JUMP_SPEED
 		on_air = true
-		$animation_tree["parameters/state/current"]=2
-		$sfx/jump.play()							
-
-
-	if (on_air):
-		
-		if (velocity.y > 0):
-			$animation_tree["parameters/state/current"]=2
-		else:
-			$animation_tree["parameters/state/current"]=3
+		$animation_tree["parameters/state/current"] = 2
+		$sfx/jump.play()
 	
-	elif (aiming):
+	if on_air:
+		if (velocity.y > 0):
+			$animation_tree["parameters/state/current"] = 2
+		else:
+			$animation_tree["parameters/state/current"] = 3
+	elif aiming:
+		# Change state to strafe.
+		$animation_tree["parameters/state/current"] = 0
 		
-		# change state to strafe
-		$animation_tree["parameters/state/current"]=0
-
-		#change aim according to camera rotation
-				
-		if (camera_x_rot >= 0): # aim up		
-			$animation_tree["parameters/aim/add_amount"]=-camera_x_rot / deg2rad(CAMERA_X_ROT_MAX)
-		else: # aim down
+		# Change aim according to camera rotation.
+		if camera_x_rot >= 0: # Aim up.
+			$animation_tree["parameters/aim/add_amount"] = -camera_x_rot / deg2rad(CAMERA_X_ROT_MAX)
+		else: # Aim down.
 			$animation_tree["parameters/aim/add_amount"] = camera_x_rot / deg2rad(CAMERA_X_ROT_MIN)
-					
-		# convert orientation to quaternions for interpolating rotation
-		var q_from = Quat(orientation.basis)
-		var q_to = Quat( $camera_base.global_transform.basis )	
-		# interpolate current rotation with desired one
-		orientation.basis = Basis(q_from.slerp(q_to,delta*ROTATION_INTERPOLATE_SPEED))
-			
-
-		$animation_tree["parameters/strafe/blend_position"]=motion
-
-
-		# get root motion transform
-		root_motion = $animation_tree.get_root_motion_transform()		
-
-		if (Input.is_action_just_pressed("shoot")):
+		
+		# Convert orientation to quaternions for interpolating rotation.
+		var q_from = orientation.basis.get_rotation_quat()
+		var q_to = $camera_base.global_transform.basis.get_rotation_quat()
+		# Interpolate current rotation with desired one.
+		orientation.basis = Basis(q_from.slerp(q_to, delta * ROTATION_INTERPOLATE_SPEED))
+		
+		
+		$animation_tree["parameters/strafe/blend_position"] = motion
+		
+		root_motion = $animation_tree.get_root_motion_transform()
+		
+		if Input.is_action_just_pressed("shoot"):
 			var shoot_from = $"Scene Root/Robot_Skeleton/Skeleton/gun_bone/shoot_from".global_transform.origin
 			var cam = $camera_base/camera_rot/Camera
 			
 			var ch_pos = $crosshair.rect_position + $crosshair.rect_size * 0.5
 			var ray_from = cam.project_ray_origin(ch_pos)
 			var ray_dir = cam.project_ray_normal(ch_pos)
-			var shoot_target
 			
-			var col = get_world().direct_space_state.intersect_ray( ray_from, ray_from + ray_dir * 1000, [self] )
-			if (col.empty()):
+			var shoot_target
+			var col = get_world().direct_space_state.intersect_ray(ray_from, ray_from + ray_dir * 1000, [self])
+			if col.empty():
 				shoot_target = ray_from + ray_dir * 1000
 			else:
 				shoot_target = col.position
-				
 			var shoot_dir = (shoot_target - shoot_from).normalized()
 			
 			var bullet = preload("res://player/bullet.tscn").instance()
-
 			get_parent().add_child(bullet)
 			bullet.global_transform.origin = shoot_from
-			bullet.direction = shoot_dir 	
+			bullet.direction = shoot_dir
 			bullet.add_collision_exception_with(self)
-			$sfx/shoot.play()							
-			
-	else: 		
-		# convert orientation to quaternions for interpolating rotation
+			$sfx/shoot.play()
+	else: # Not in air or aiming, idle.
+		# Convert orientation to quaternions for interpolating rotation.
+		var target = camera_z * motion.y - camera_x * motion.x
+		if target.length() > 0.001:
+			var q_from = orientation.basis.get_rotation_quat()
+			var q_to = Quat(Transform().looking_at(target, Vector3.UP).basis)
+			# Interpolate current rotation with desired one
+			orientation.basis = Basis(q_from.slerp(q_to, delta * ROTATION_INTERPOLATE_SPEED))
 		
-		var target = - cam_x * motion.x -  cam_z * motion.y
-		if (target.length() > 0.001):
-			var q_from = Quat(orientation.basis)
-			var q_to = Quat(Transform().looking_at(target,Vector3(0,1,0)).basis)
+		# Aim to zero (no aiming while walking).
+		$animation_tree["parameters/aim/add_amount"] = 0
+		# Change state to walk.
+		$animation_tree["parameters/state/current"] = 1
+		# Blend position for walk speed based on motion.
+		$animation_tree["parameters/walk/blend_position"] = Vector2(motion.length(), 0) 
+		
+		root_motion = $animation_tree.get_root_motion_transform()
 	
-			# interpolate current rotation with desired one
-			orientation.basis = Basis(q_from.slerp(q_to,delta*ROTATION_INTERPOLATE_SPEED))
-		
-		#aim to zero (no aiming while walking
-		
-		$animation_tree["parameters/aim/add_amount"]=0
-		# change state to walk
-		$animation_tree["parameters/state/current"]=1
-		# blend position for walk speed based on motion
-		$animation_tree["parameters/walk/blend_position"]=Vector2(motion.length(),0 ) 
-		
-		# get root motion transform
-		root_motion = $animation_tree.get_root_motion_transform()		
-
-	
-	# apply root motion to orientation
+	# Apply root motion to orientation.
 	orientation *= root_motion
 	
 	var h_velocity = orientation.origin / delta
 	velocity.x = h_velocity.x
-	velocity.z = h_velocity.z		
-	velocity += GRAVITY * delta
-	velocity = move_and_slide(velocity,Vector3(0,1,0))
-
-	orientation.origin = Vector3() #clear accumulated root motion displacement (was applied to speed)
-	orientation = orientation.orthonormalized() # orthonormalize orientation
+	velocity.z = h_velocity.z
+	velocity += gravity * delta
+	velocity = move_and_slide(velocity, Vector3.UP)
+	
+	orientation.origin = Vector3() # Clear accumulated root motion displacement (was applied to speed).
+	orientation = orientation.orthonormalized() # Orthonormalize orientation.
 	
 	$"Scene Root".global_transform.basis = orientation.basis
+
+
+func _input(event):
+	if event is InputEventMouseMotion:
+		$camera_base.rotate_y(-event.relative.x * CAMERA_ROTATION_SPEED)
+		$camera_base.orthonormalize() # After relative transforms, camera needs to be renormalized.
+		camera_x_rot += event.relative.y * CAMERA_ROTATION_SPEED
+		camera_x_rot = clamp(camera_x_rot, deg2rad(CAMERA_X_ROT_MIN), deg2rad(CAMERA_X_ROT_MAX))
+		$camera_base/camera_rot.rotation.x = camera_x_rot
 	
-	
-		
-		
-	
-	
-func _init():
-	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+	if event.is_action_pressed("quit"):
+		get_tree().quit()


### PR DESCRIPTION
This PR changes the scripts to conform to the [GDScript style guide](https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_styleguide.html), among other small improvements. List of changes (there may be more that aren't listed here, it's hard to keep track):

* Removed stray indentation.

* Removed empty functions.

* Removed unnecessary parenthesis.

* Exactly two empty lines between methods.

* Proper spacing around commas and operators. Previously it was wrong almost everywhere.

* Comments now start with a space and capital letter and end with a period.

* Change order of constants, variables, and methods to match the style guide.

* Where appropriate, use enums instead of constants.

* Use `Vector3.UP` instead of `Vector3(0,1,0)`

* Some logic simplification, like multiplying a vector by `2` instead of `Vector3(2,2,2)`, and changing `.affine_inverse().xform()` to `xform_inv()`.

* Fix a warning about unused return value in `menu.gd`

* I renamed `do_shoot` to `shoot` in `red_robot.gd`.

* Remove variables that are declared and then only used once, when the original expression can easily just be used in place of the variable's usage instead.

* Use variables for things that are calculated multiple times, this should increase performance.

CC @akien-mga 