### PR TITLE
Pre-compile Bullet shader to avoid stutter on first use

### DIFF
--- a/level/level.tscn
+++ b/level/level.tscn
@@ -1,15 +1,17 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://level/level.gd" type="Script" id=1]
 [ext_resource path="res://level/geometry/demolevel.dae" type="PackedScene" id=2]
-[ext_resource path="res://level/giprobe_data.res" type="GIProbeData" id=3]
-[ext_resource path="res://player/player.tscn" type="PackedScene" id=4]
-[ext_resource path="res://enemies/red_robot/red_robot.tscn" type="PackedScene" id=5]
-[ext_resource path="res://music/music.ogg" type="AudioStream" id=6]
-[ext_resource path="res://level/lightdata.res" type="BakedLightmapData" id=7]
-[ext_resource path="res://fx/smoke/smoke.tscn" type="PackedScene" id=8]
-[ext_resource path="res://fx/plasma/plasma.tscn" type="PackedScene" id=9]
-[ext_resource path="res://level/forklift/forklift.tscn" type="PackedScene" id=10]
+[ext_resource path="res://level/shader_cache.gd" type="Script" id=3]
+[ext_resource path="res://player/bullet.tscn" type="PackedScene" id=4]
+[ext_resource path="res://level/giprobe_data.res" type="GIProbeData" id=5]
+[ext_resource path="res://player/player.tscn" type="PackedScene" id=6]
+[ext_resource path="res://enemies/red_robot/red_robot.tscn" type="PackedScene" id=7]
+[ext_resource path="res://music/music.ogg" type="AudioStream" id=8]
+[ext_resource path="res://level/lightdata.res" type="BakedLightmapData" id=9]
+[ext_resource path="res://fx/smoke/smoke.tscn" type="PackedScene" id=10]
+[ext_resource path="res://fx/plasma/plasma.tscn" type="PackedScene" id=11]
+[ext_resource path="res://level/forklift/forklift.tscn" type="PackedScene" id=12]
 
 [sub_resource type="Environment" id=1]
 background_mode = 1
@@ -75,7 +77,6 @@ tracks/0/keys = {
 script = ExtResource( 1 )
 
 [node name="Scene Root" parent="." instance=ExtResource( 2 )]
-editor/display_folded = true
 
 [node name="Point" parent="Scene Root" index="109"]
 transform = Transform( 0.999986, -0.00522796, -2.28521e-10, 0, -4.37114e-08, 1, -0.00522796, -0.999986, -4.37108e-08, 8.46026, -4.73813, 85.4573 )
@@ -204,6 +205,11 @@ transform = Transform( 1, 0, 7.45058e-09, 5.72164e-11, 1, 8.73443e-11, -1.49012e
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource( 1 )
 
+[node name="shader_cache" type="Node" parent="WorldEnvironment"]
+script = ExtResource( 3 )
+
+[node name="bullet" parent="WorldEnvironment/shader_cache" instance=ExtResource( 4 )]
+
 [node name="GIProbe" type="GIProbe" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -6.09263, 1.28266, 2.88598 )
 subdiv = 2
@@ -211,21 +217,21 @@ extents = Vector3( 113.946, 48.8048, 117.028 )
 energy = 2.2
 propagation = 1.0
 interior = true
-data = ExtResource( 3 )
+data = ExtResource( 5 )
 
-[node name="robot" parent="." instance=ExtResource( 4 )]
+[node name="player" parent="." instance=ExtResource( 6 )]
 transform = Transform( -0.575826, 0, -0.817573, 0, 1, 0, 0.817573, 0, -0.575826, 64.8183, -1.0765, 78.7639 )
 
-[node name="big_robot" parent="." instance=ExtResource( 5 )]
+[node name="big_robot" parent="." instance=ExtResource( 7 )]
 transform = Transform( 0.843905, 0, -0.536493, 0, 1, 0, 0.536493, 0, 0.843905, 71.5907, -6.05686, 46.2736 )
 
-[node name="big_robot2" parent="." instance=ExtResource( 5 )]
+[node name="big_robot2" parent="." instance=ExtResource( 7 )]
 transform = Transform( 0.338334, 0, 0.941027, 0, 1, 0, -0.941027, 0, 0.338334, 53.2126, -6.05686, 15.9321 )
 
-[node name="big_robot3" parent="." instance=ExtResource( 5 )]
+[node name="big_robot3" parent="." instance=ExtResource( 7 )]
 transform = Transform( -0.164432, 0, 0.986389, 0, 1, 0, -0.986389, 0, -0.164432, -2.96096, -11.6923, 20.2343 )
 
-[node name="big_robot4" parent="." instance=ExtResource( 5 )]
+[node name="big_robot4" parent="." instance=ExtResource( 7 )]
 transform = Transform( -0.164432, 0, 0.986389, 0, 1, 0, -0.986389, 0, -0.164432, -9.15526, -11.6923, -16.9238 )
 
 [node name="sound_outside" type="Area" parent="."]
@@ -248,7 +254,7 @@ transform = Transform( 1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0
 shape = SubResource( 2 )
 
 [node name="music" type="AudioStreamPlayer" parent="."]
-stream = ExtResource( 6 )
+stream = ExtResource( 8 )
 autoplay = true
 
 [node name="refprobes" type="Spatial" parent="."]
@@ -283,31 +289,30 @@ bake_energy = 2.2
 bake_extents = Vector3( 127.692, 56.9907, 126.895 )
 capture_cell_size = 4.0
 image_path = "res://level/baked"
-light_data = ExtResource( 7 )
+light_data = ExtResource( 9 )
 
-[node name="smoke1" parent="." instance=ExtResource( 8 )]
+[node name="smoke1" parent="." instance=ExtResource( 10 )]
 transform = Transform( 2.81076, 0, 0, 0, 2.81076, 0, 0, 0, 2.81076, -31.0061, -16.8843, 64.9964 )
 
-[node name="smoke3" parent="." instance=ExtResource( 8 )]
+[node name="smoke3" parent="." instance=ExtResource( 10 )]
 transform = Transform( 2.81076, 0, 0, 0, 2.81076, 0, 0, 0, 2.81076, -57.857, -16.8843, 48.4801 )
 
-[node name="smoke2" parent="." instance=ExtResource( 8 )]
+[node name="smoke2" parent="." instance=ExtResource( 10 )]
 transform = Transform( 2.81076, 0, 0, 0, 2.81076, 0, 0, 0, 2.81076, 65.1483, -16.8843, -12.7312 )
 
-[node name="plasma" parent="." instance=ExtResource( 9 )]
+[node name="plasma" parent="." instance=ExtResource( 11 )]
 transform = Transform( 4.91931, 0, 0, 0, 4.91931, 0, 0, 0, 4.91931, 0, -2.27672, 0.025551 )
 
 [node name="forklifts_a" type="Spatial" parent="."]
 
-[node name="Spatial" parent="forklifts_a" instance=ExtResource( 10 )]
+[node name="Spatial" parent="forklifts_a" instance=ExtResource( 12 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 67.8049, 2.27771, 0 )
 
-[node name="Spatial2" parent="forklifts_a" instance=ExtResource( 10 )]
+[node name="Spatial2" parent="forklifts_a" instance=ExtResource( 12 )]
 transform = Transform( -1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, -68.2496, 2.27771, 0 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="forklifts_a"]
 autoplay = "mawaru"
 anims/mawaru = SubResource( 3 )
-
 
 [editable path="Scene Root"]

--- a/level/shader_cache.gd
+++ b/level/shader_cache.gd
@@ -1,0 +1,18 @@
+extends Node
+
+var fade_in_frame_counter = 60
+
+func _ready():
+	# We don't want the cache bullet to make noise. So just get rid of its audio.
+	$bullet/explosion2.queue_free()
+
+
+func _physics_process(_delta):
+	fade_in_frame_counter -= 1
+	# Fade in progressively to hide artifacts.
+	if fade_in_frame_counter == 50:
+		# Hide after a few frames to be sure the shaders compiled.
+		$bullet.hide()
+	if fade_in_frame_counter == 0:
+		# This node has served its purpose, and now it's time to stop existing.
+		self.queue_free()

--- a/player/bullet.tscn
+++ b/player/bullet.tscn
@@ -1,44 +1,35 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://player/bullet.gd" type="Script" id=1]
 [ext_resource path="res://player/blue_myst.png" type="Texture" id=2]
 [ext_resource path="res://player/fx_bullet_explodewav.wav" type="AudioStream" id=3]
 
-[sub_resource type="SpatialMaterial" id=1]
-albedo_color = Color( 0, 0, 0, 1 )
-roughness = 0.0
-emission_enabled = true
-emission = Color( 0.109804, 0.894118, 1, 1 )
-emission_energy = 7.34
-emission_operator = 0
-emission_on_uv2 = false
-
-[sub_resource type="SphereMesh" id=2]
+[sub_resource type="SphereMesh" id=18]
 radial_segments = 9
 rings = 5
 
-[sub_resource type="Gradient" id=3]
+[sub_resource type="Gradient" id=2]
 colors = PoolColorArray( 1, 1, 1, 1, 1, 1, 1, 0 )
 
-[sub_resource type="GradientTexture" id=4]
-gradient = SubResource( 3 )
+[sub_resource type="GradientTexture" id=3]
+gradient = SubResource( 2 )
 
-[sub_resource type="Curve" id=5]
+[sub_resource type="Curve" id=4]
 max_value = 4.0
 _data = [ Vector2( 0.150987, 4 ), 0.0, 0.0, 0, 0, Vector2( 1, 0.6936 ), 0.0, 0.0, 0, 0 ]
 
-[sub_resource type="CurveTexture" id=6]
-curve = SubResource( 5 )
+[sub_resource type="CurveTexture" id=5]
+curve = SubResource( 4 )
 
-[sub_resource type="ParticlesMaterial" id=7]
+[sub_resource type="ParticlesMaterial" id=6]
 spread = 180.0
 gravity = Vector3( 0, -1, 0 )
 initial_velocity = 1.0
 scale = 0.1
-scale_curve = SubResource( 6 )
-color_ramp = SubResource( 4 )
+scale_curve = SubResource( 5 )
+color_ramp = SubResource( 3 )
 
-[sub_resource type="SpatialMaterial" id=8]
+[sub_resource type="SpatialMaterial" id=7]
 flags_transparent = true
 vertex_color_use_as_albedo = true
 vertex_color_is_srgb = true
@@ -49,41 +40,41 @@ emission_energy = 2.0
 emission_operator = 0
 emission_on_uv2 = false
 
-[sub_resource type="SphereMesh" id=9]
-material = SubResource( 8 )
+[sub_resource type="SphereMesh" id=8]
+material = SubResource( 7 )
 radius = 0.1
 height = 0.2
 radial_segments = 5
 rings = 3
 
-[sub_resource type="SphereShape" id=10]
+[sub_resource type="SphereShape" id=9]
 radius = 0.170413
 
-[sub_resource type="Gradient" id=11]
+[sub_resource type="Gradient" id=10]
 offsets = PoolRealArray( 0, 0.33, 1 )
 colors = PoolColorArray( 1, 1, 1, 1, 1, 1, 1, 0.133333, 1, 1, 1, 0 )
 
-[sub_resource type="GradientTexture" id=12]
-gradient = SubResource( 11 )
+[sub_resource type="GradientTexture" id=11]
+gradient = SubResource( 10 )
 
-[sub_resource type="Curve" id=13]
+[sub_resource type="Curve" id=12]
 max_value = 2.0
 _data = [ Vector2( 0, 0.3856 ), 0.0, 0.0, 0, 0, Vector2( 0.0612366, 1 ), 0.0, 0.0, 0, 0, Vector2( 0.999703, 1.4752 ), 0.0, 0.0, 0, 0 ]
 
-[sub_resource type="CurveTexture" id=14]
-curve = SubResource( 13 )
+[sub_resource type="CurveTexture" id=13]
+curve = SubResource( 12 )
 
-[sub_resource type="ParticlesMaterial" id=15]
+[sub_resource type="ParticlesMaterial" id=14]
 spread = 180.0
 gravity = Vector3( 0, 0, 0 )
 initial_velocity = 1.1
 angular_velocity = 360.0
 angular_velocity_random = 1.0
 scale = 0.8
-scale_curve = SubResource( 14 )
-color_ramp = SubResource( 12 )
+scale_curve = SubResource( 13 )
+color_ramp = SubResource( 11 )
 
-[sub_resource type="SpatialMaterial" id=16]
+[sub_resource type="SpatialMaterial" id=15]
 flags_transparent = true
 flags_unshaded = true
 vertex_color_use_as_albedo = true
@@ -97,10 +88,10 @@ albedo_texture = ExtResource( 2 )
 proximity_fade_enable = true
 proximity_fade_distance = 0.8
 
-[sub_resource type="QuadMesh" id=17]
-material = SubResource( 16 )
+[sub_resource type="QuadMesh" id=16]
+material = SubResource( 15 )
 
-[sub_resource type="Animation" id=18]
+[sub_resource type="Animation" id=17]
 resource_name = "explode"
 length = 3.0
 tracks/0/type = "value"
@@ -183,9 +174,8 @@ script = ExtResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 transform = Transform( 0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0 )
-material_override = SubResource( 1 )
 cast_shadow = 0
-mesh = SubResource( 2 )
+mesh = SubResource( 18 )
 material/0 = null
 
 [node name="Particles" type="Particles" parent="."]
@@ -193,8 +183,8 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00988865, 0, 0 )
 amount = 100
 lifetime = 0.3
 local_coords = false
-process_material = SubResource( 7 )
-draw_pass_1 = SubResource( 9 )
+process_material = SubResource( 6 )
+draw_pass_1 = SubResource( 8 )
 
 [node name="OmniLight" type="OmniLight" parent="."]
 light_color = Color( 0, 1, 0.952941, 1 )
@@ -206,17 +196,17 @@ omni_attenuation = 2.0
 omni_shadow_mode = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
-shape = SubResource( 10 )
+shape = SubResource( 9 )
 
 [node name="explosion" type="Particles" parent="."]
 emitting = false
 amount = 6
 explosiveness = 1.0
-process_material = SubResource( 15 )
-draw_pass_1 = SubResource( 17 )
+process_material = SubResource( 14 )
+draw_pass_1 = SubResource( 16 )
 
 [node name="anim" type="AnimationPlayer" parent="."]
-anims/explode = SubResource( 18 )
+anims/explode = SubResource( 17 )
 
 [node name="explosion2" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 3 )

--- a/player/bullet_material.tres
+++ b/player/bullet_material.tres
@@ -1,0 +1,11 @@
+[gd_resource type="SpatialMaterial" format=2]
+
+[resource]
+albedo_color = Color( 0, 0, 0, 1 )
+roughness = 0.0
+emission_enabled = true
+emission = Color( 0.109804, 0.894118, 1, 1 )
+emission_energy = 7.34
+emission_operator = 0
+emission_on_uv2 = false
+

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -215,7 +215,7 @@ tracks/1/keys = {
 [sub_resource type="AudioStreamRandomPitch" id=27]
 audio_stream = ExtResource( 7 )
 
-[node name="robot" type="KinematicBody"]
+[node name="player" type="KinematicBody"]
 collision_layer = 3
 script = ExtResource( 1 )
 
@@ -294,6 +294,5 @@ stream = ExtResource( 6 )
 
 [node name="shoot" type="AudioStreamPlayer" parent="sfx"]
 stream = SubResource( 27 )
-
 
 [editable path="Scene Root"]


### PR DESCRIPTION
This is partially a rebase and partially a rewrite of #24, except only the bullet shader caching, it does not include any fading. Instead of making it part of the player, I made a self-deleting node. The children of this node are at the origin, which is within the camera frustum of the player's start location.

One other minor change, I renamed "robot" to "player" in `player.tscn`.

I assigned the label "bug" because I think the stuttering is a bug to begin with. Let me know if this label isn't appropriate here.