### PR TITLE
Tweak controller support

### DIFF
--- a/level/level.gd
+++ b/level/level.gd
@@ -35,13 +35,13 @@ func _ready():
 		pass
 	elif settings.resolution == settings.Resolution.RES_1080:
 		var minsize = Vector2(OS.window_size.x * 1080 / OS.window_size.y, 1080.0)
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT,SceneTree.STRETCH_ASPECT_KEEP_HEIGHT,minsize)
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
 	elif settings.resolution == settings.Resolution.RES_720:
 		var minsize = Vector2(OS.window_size.x * 720 / OS.window_size.y, 720.0)
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT,SceneTree.STRETCH_ASPECT_KEEP_HEIGHT,minsize)
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
 	elif settings.resolution == settings.Resolution.RES_576:
 		var minsize = Vector2(OS.window_size.x * 576 / OS.window_size.y, 576.0)
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT,SceneTree.STRETCH_ASPECT_KEEP_HEIGHT,minsize)
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
 
 
 func _input(event):

--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -58,27 +58,27 @@ func _on_settings_pressed():
 	$ui/settings/actions/cancel.grab_focus()
 	
 	if settings.gi_quality == settings.GIQuality.HIGH:
-		$ui/settings/gi/gi_high.pressed=true
+		$ui/settings/gi/gi_high.pressed = true
 	elif settings.gi_quality == settings.GIQuality.LOW:
-		$ui/settings/gi/gi_low.pressed=true
+		$ui/settings/gi/gi_low.pressed = true
 	elif settings.gi_quality == settings.GIQuality.DISABLED:
-		$ui/settings/gi/gi_disabled.pressed=true
+		$ui/settings/gi/gi_disabled.pressed = true
 
 	if settings.aa_quality == settings.AAQuality.AA_8X:
-		$ui/settings/aa/aa_8x.pressed=true
+		$ui/settings/aa/aa_8x.pressed = true
 	elif settings.aa_quality == settings.AAQuality.AA_4X:
-		$ui/settings/aa/aa_4x.pressed=true
+		$ui/settings/aa/aa_4x.pressed = true
 	elif settings.aa_quality == settings.AAQuality.AA_2X:
-		$ui/settings/aa/aa_2x.pressed=true
-	elif settings.aa_quality == settings.AAQuality.AA_DISABLED:
-		$ui/settings/aa/aa_disabled.pressed=true
+		$ui/settings/aa/aa_2x.pressed = true
+	elif settings.aa_quality == settings.AAQuality.DISABLED:
+		$ui/settings/aa/aa_disabled.pressed = true
 
 	if settings.ssao_quality == settings.SSAOQuality.HIGH:
-		$ui/settings/ssao/ssao_high.pressed=true
+		$ui/settings/ssao/ssao_high.pressed = true
 	elif settings.ssao_quality == settings.SSAOQuality.LOW:
-		$ui/settings/ssao/ssao_low.pressed=true
+		$ui/settings/ssao/ssao_low.pressed = true
 	elif settings.ssao_quality == settings.SSAOQuality.DISABLED:
-		$ui/settings/ssao/ssao_disabled.pressed=true
+		$ui/settings/ssao/ssao_disabled.pressed = true
 		
 	if settings.resolution == settings.Resolution.NATIVE:
 		$ui/settings/resolution/resolution_native.pressed = true
@@ -118,7 +118,7 @@ func _on_apply_pressed():
 	elif $ui/settings/aa/aa_2x.pressed:
 		settings.aa_quality = settings.AAQuality.AA_2X
 	elif $ui/settings/aa/aa_disabled.pressed:
-		settings.aa_quality = settings.AAQuality.AA_DISABLED
+		settings.aa_quality = settings.AAQuality.DISABLED
 	
 	if $ui/settings/ssao/ssao_high.pressed:
 		settings.ssao_quality = settings.SSAOQuality.HIGH

--- a/project.godot
+++ b/project.godot
@@ -115,24 +115,32 @@ move_left={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
  ]
 }
 move_right={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
  ]
 }
 move_forward={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
  ]
 }
 move_back={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
  ]
 }
 jump={
@@ -160,22 +168,22 @@ quit={
  ]
 }
 view_left={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":2,"axis_value":-1.0,"script":null)
  ]
 }
 view_right={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":2,"axis_value":1.0,"script":null)
  ]
 }
 view_up={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":3,"axis_value":1.0,"script":null)
  ]
 }
 view_down={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":3,"axis_value":-1.0,"script":null)
  ]
 }


### PR DESCRIPTION
* The D-pad is now supported for movement.

* Increase the sensitivity by 3x for rotating the camera with controllers. It was a bit slow before.

* Reduce the sensitivity while aiming to passively assist with aiming (0.5 multiplier). I added this effect with the mouse as well, but it's not as strong (0.75 multiplier).

* Shrink the deadzone to 0.2, since 0.5 seemed to be way too high for the Steam controller.

I also fixed a minor issue with AAQuality.DISABLED and some style problems.