### PR TITLE
Update default_env.tres to the Godot 3.1/3.2 default environment

### DIFF
--- a/default_env.tres
+++ b/default_env.tres
@@ -1,13 +1,6 @@
 [gd_resource type="Environment" load_steps=2 format=2]
 
 [sub_resource type="ProceduralSky" id=1]
-sky_top_color = Color( 0.0470588, 0.454902, 0.976471, 1 )
-sky_horizon_color = Color( 0.556863, 0.823529, 0.909804, 1 )
-sky_curve = 0.25
-ground_bottom_color = Color( 0.101961, 0.145098, 0.188235, 1 )
-ground_horizon_color = Color( 0.482353, 0.788235, 0.952941, 1 )
-ground_curve = 0.01
-sun_energy = 16.0
 
 [resource]
 background_mode = 2


### PR DESCRIPTION
The 3.1/3.2 environment is far less blue. The update only requires removing some of the values, so that Godot's new default values are used. This is only visible in the editor, and isn't used in-game.