### PR TITLE
[3.2.1] Implement some in-game debug text

### DIFF
--- a/level/debug.gd
+++ b/level/debug.gd
@@ -1,0 +1,9 @@
+extends Label
+
+func _process(delta):
+	if Input.is_action_just_pressed("toggle_debug"):
+		visible = !visible
+	
+	text = "FPS: " + str(Engine.get_frames_per_second())
+	text += "\nVSync: " + ("on" if ProjectSettings.get_setting("display/window/vsync/use_vsync") else "off")
+	text += "\nMemory: " + "%3.2f" % (OS.get_static_memory_usage() / 1048576.0) + " MiB"

--- a/level/level.tscn
+++ b/level/level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://level/level.gd" type="Script" id=1]
 [ext_resource path="res://level/geometry/demolevel.dae" type="PackedScene" id=2]
@@ -12,6 +12,7 @@
 [ext_resource path="res://fx/smoke/smoke.tscn" type="PackedScene" id=10]
 [ext_resource path="res://fx/plasma/plasma.tscn" type="PackedScene" id=11]
 [ext_resource path="res://level/forklift/forklift.tscn" type="PackedScene" id=12]
+[ext_resource path="res://level/debug.gd" type="Script" id=13]
 
 [sub_resource type="Environment" id=1]
 background_mode = 1
@@ -315,5 +316,19 @@ transform = Transform( -1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, -68.249
 [node name="AnimationPlayer" type="AnimationPlayer" parent="forklifts_a"]
 autoplay = "mawaru"
 anims/mawaru = SubResource( 3 )
+
+[node name="Debug" type="Label" parent="."]
+visible = false
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 40.0
+margin_bottom = 14.0
+text = "FPS: 0
+VSync:
+Memory:"
+script = ExtResource( 13 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [editable path="Scene Root"]

--- a/project.godot
+++ b/project.godot
@@ -193,6 +193,11 @@ toggle_fullscreen={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777254,"unicode":0,"echo":false,"script":null)
  ]
 }
+toggle_debug={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777246,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [layer_names]
 


### PR DESCRIPTION
![Screenshot from 2020-06-14 20-42-30](https://user-images.githubusercontent.com/1646875/84609102-8eebfa80-ae83-11ea-8429-5f661c7c5881.png)

Adds some debug text in the corner of the screen, which includes FPS, VSync status, and memory usage, available by pressing F3. This can be used to benchmark the demo or to test Godot.

I'm backporting this from #67 because I think it would be useful for benchmarking and comparing.