### PR TITLE
Fix some minor problems

### DIFF
--- a/level/debug.gd
+++ b/level/debug.gd
@@ -1,6 +1,6 @@
 extends Label
 
-func _process(delta):
+func _process(_delta):
 	if Input.is_action_just_pressed("toggle_debug"):
 		visible = !visible
 	

--- a/level/geometry/scenes/core.tscn
+++ b/level/geometry/scenes/core.tscn
@@ -6,7 +6,6 @@
 [ext_resource path="res://level/geometry/scenes/collision/radial_player_only.tscn" type="PackedScene" id=4]
 [ext_resource path="res://level/textures/plasma.png" type="Texture" id=5]
 
-
 [sub_resource type="SpatialMaterial" id=1]
 flags_transparent = true
 flags_unshaded = true

--- a/level/shader_cache.gd
+++ b/level/shader_cache.gd
@@ -3,8 +3,8 @@ extends Node
 var fade_in_frame_counter = 100
 
 func _ready():
-	# We don't want the cache bullet to make noise. So just get rid of its audio.
-	$Bullet/ExplosionAudio.queue_free()
+	# We don't want the cache bullet to make noise. So make it silent.
+	$Bullet/ExplosionAudio.unit_db = -INF
 
 
 func _physics_process(_delta):


### PR DESCRIPTION
* Add an underscore to debug's delta.

* Change shader cache to set volume to -INF instead of deleting the audio node. I went on a truly bizzare wild goose chase and discovered that an alternative solution is to delete the `CentralCylinder3` node in `core.tscn` (wtf‽). I'm still confused as to how that works.