### PR TITLE
Manage french and belgian keyboard layouts automatically

### DIFF
--- a/main/main.gd
+++ b/main/main.gd
@@ -2,6 +2,18 @@ extends Node
 
 func _ready():
 	OS.window_fullscreen = Settings.fullscreen
+	
+	# Manage french and belgian keyboard layouts
+	match OS.keyboard_get_layout_language(OS.keyboard_get_current_layout()):
+		"fr","be":
+			var ev_fr_forward = InputEventKey.new()
+			ev_fr_forward.scancode = KEY_Z
+			InputMap.action_add_event("move_forward", ev_fr_forward)
+			
+			var ev_fr_left = InputEventKey.new()
+			ev_fr_left.scancode = KEY_Q
+			InputMap.action_add_event("move_left", ev_fr_left)
+			
 	go_to_main_menu()
 
 


### PR DESCRIPTION
This PR is intended to add automatic management for french and belgian keyboards (AZERTY) so that usual ZQSD keys are used for movement instead of WASD on other layouts (especially QWERTY).

I only took care of the layouts I know, but evolution should be relatively easy.

Also, I'd like to discuss the "right" way to do this. I wonder if Godot should manage this instead of doing this kind of hack? If not, then wouldn't it be better to actually replace (create new & delete old) the default InputEvents that were defined in the InputMap, instead of just adding new ones? With this hack in its current state, with a French/Belgian keyboard layout, there are actually 2 keys defined fort "move_forward" and "move_left".