### PR TITLE
Prevent aiming at other bullets by setting their collision layer to zero

### DIFF
--- a/player/bullet/bullet.tscn
+++ b/player/bullet/bullet.tscn
@@ -170,6 +170,7 @@ tracks/5/keys = {
 }
 
 [node name="Bullet" type="KinematicBody"]
+collision_layer = 0
 script = ExtResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]


### PR DESCRIPTION
Previously, this could affect your aim in a minor way, since if you aimed at a bullet, it counted. Now, if you aim at a bullet, it won't count that, and you will actually be aiming at the object behind the bullet.