### PR TITLE
On jump input, immediately increase airborne time to MIN_AIRBORNE_TIME.

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -108,6 +108,8 @@ func _physics_process(delta):
 	if not on_air and Input.is_action_just_pressed("jump"):
 		velocity.y = JUMP_SPEED
 		on_air = true
+		# Increase airborne time so next frame on_air is still true
+		airborne_time = MIN_AIRBORNE_TIME
 		animation_tree["parameters/state/current"] = 2
 		sound_effect_jump.play()
 	


### PR DESCRIPTION
This is necessary, otherwise the frame after jumping it's possible that
on_air will be unset due to airborne time being less than
MIN_AIRBORNE_TIME. This causes jumps to feel sluggish since the player's
horizontal speed gets lowered.