### PR TITLE
Add a bloom quality setting

### DIFF
--- a/level/level.gd
+++ b/level/level.gd
@@ -15,7 +15,7 @@ func _ready():
 	else:
 		$GIProbe.hide()
 		$ReflectionProbes.show()
-	
+
 	if Settings.aa_quality == Settings.AAQuality.AA_8X:
 		get_node("/root").msaa = Viewport.MSAA_8X
 	elif Settings.aa_quality == Settings.AAQuality.AA_4X:
@@ -24,14 +24,24 @@ func _ready():
 		get_node("/root").msaa = Viewport.MSAA_2X
 	else:
 		get_node("/root").msaa = Viewport.MSAA_DISABLED
-	
+
 	if Settings.ssao_quality == Settings.SSAOQuality.HIGH:
 		world_environment.environment.ssao_quality = world_environment.environment.SSAO_QUALITY_HIGH
 	elif Settings.ssao_quality == Settings.SSAOQuality.LOW:
 		world_environment.environment.ssao_quality = world_environment.environment.SSAO_QUALITY_LOW
 	else:
 		world_environment.environment.ssao_enabled = false
-	
+
+	if Settings.bloom_quality == Settings.BloomQuality.HIGH:
+		world_environment.environment.glow_enabled = true
+		world_environment.environment.glow_bicubic_upscale = true
+	elif Settings.bloom_quality == Settings.BloomQuality.LOW:
+		world_environment.environment.glow_enabled = true
+		world_environment.environment.glow_bicubic_upscale = false
+	else:
+		world_environment.environment.glow_enabled = false
+		world_environment.environment.glow_bicubic_upscale = false
+
 	if Settings.resolution == Settings.Resolution.NATIVE:
 		pass
 	elif Settings.resolution == Settings.Resolution.RES_1080:

--- a/main/main.gd
+++ b/main/main.gd
@@ -16,11 +16,11 @@ func replace_main_scene(resource):
 
 func change_scene(resource : Resource):
 	var node = resource.instance()
-	
+
 	for child in get_children():
 		remove_child(child)
 		child.queue_free()
 	add_child(node)
-	
+
 	node.connect("quit", self, "go_to_main_menu")
 	node.connect("replace_main_scene", self, "replace_main_scene")

--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -34,6 +34,11 @@ onready var ssao_high = ssao_menu.get_node(@"High")
 onready var ssao_low = ssao_menu.get_node(@"Low")
 onready var ssao_disabled = ssao_menu.get_node(@"Disabled")
 
+onready var bloom_menu = settings_menu.get_node(@"Bloom")
+onready var bloom_high = bloom_menu.get_node(@"High")
+onready var bloom_low = bloom_menu.get_node(@"Low")
+onready var bloom_disabled = bloom_menu.get_node(@"Disabled")
+
 onready var resolution_menu = settings_menu.get_node(@"Resolution")
 onready var resolution_native = resolution_menu.get_node(@"Native")
 onready var resolution_1080 = resolution_menu.get_node(@"1080")
@@ -99,7 +104,7 @@ func _on_settings_pressed():
 	main.hide()
 	settings_menu.show()
 	settings_action_cancel.grab_focus()
-	
+
 	if Settings.gi_quality == Settings.GIQuality.HIGH:
 		gi_high.pressed = true
 	elif Settings.gi_quality == Settings.GIQuality.LOW:
@@ -122,7 +127,14 @@ func _on_settings_pressed():
 		ssao_low.pressed = true
 	elif Settings.ssao_quality == Settings.SSAOQuality.DISABLED:
 		ssao_disabled.pressed = true
-		
+
+	if Settings.bloom_quality == Settings.BloomQuality.HIGH:
+		bloom_high.pressed = true
+	elif Settings.bloom_quality == Settings.BloomQuality.LOW:
+		bloom_low.pressed = true
+	elif Settings.bloom_quality == Settings.BloomQuality.DISABLED:
+		bloom_disabled.pressed = true
+
 	if Settings.resolution == Settings.Resolution.NATIVE:
 		resolution_native.pressed = true
 	elif Settings.resolution == Settings.Resolution.RES_1080:
@@ -146,14 +158,14 @@ func _on_apply_pressed():
 	main.show()
 	play_button.grab_focus()
 	settings_menu.hide()
-	
+
 	if gi_high.pressed:
 		Settings.gi_quality = Settings.GIQuality.HIGH
 	elif gi_low.pressed:
 		Settings.gi_quality = Settings.GIQuality.LOW
 	elif gi_disabled.pressed:
 		Settings.gi_quality = Settings.GIQuality.DISABLED
-	
+
 	if aa_8x.pressed:
 		Settings.aa_quality = Settings.AAQuality.AA_8X
 	elif aa_4x.pressed:
@@ -162,14 +174,21 @@ func _on_apply_pressed():
 		Settings.aa_quality = Settings.AAQuality.AA_2X
 	elif aa_disabled.pressed:
 		Settings.aa_quality = Settings.AAQuality.DISABLED
-	
+
 	if ssao_high.pressed:
 		Settings.ssao_quality = Settings.SSAOQuality.HIGH
 	elif ssao_low.pressed:
 		Settings.ssao_quality = Settings.SSAOQuality.LOW
 	elif ssao_disabled.pressed:
 		Settings.ssao_quality = Settings.SSAOQuality.DISABLED
-	
+
+	if bloom_high.pressed:
+		Settings.bloom_quality = Settings.BloomQuality.HIGH
+	elif bloom_low.pressed:
+		Settings.bloom_quality = Settings.BloomQuality.LOW
+	elif bloom_disabled.pressed:
+		Settings.bloom_quality = Settings.BloomQuality.DISABLED
+
 	if resolution_native.pressed:
 		Settings.resolution = Settings.Resolution.NATIVE
 	elif resolution_1080.pressed:
@@ -180,7 +199,7 @@ func _on_apply_pressed():
 		Settings.resolution = Settings.Resolution.RES_540
 
 	Settings.fullscreen = fullscreen_yes.pressed
-	
+
 	# Apply the setting directly
 	OS.window_fullscreen = Settings.fullscreen
 

--- a/menu/menu.tscn
+++ b/menu/menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=2]
+[gd_scene load_steps=38 format=2]
 
 [ext_resource path="res://menu/menu.gd" type="Script" id=1]
 [ext_resource path="res://menu/experiment.hdr" type="Texture" id=2]
@@ -90,6 +90,8 @@ Label/styles/normal = null
 [sub_resource type="ButtonGroup" id=11]
 
 [sub_resource type="ButtonGroup" id=12]
+
+[sub_resource type="ButtonGroup" id=19]
 
 [sub_resource type="ButtonGroup" id=13]
 
@@ -389,6 +391,54 @@ margin_bottom = 57.0
 size_flags_horizontal = 3
 toggle_mode = true
 group = SubResource( 12 )
+text = "Disabled"
+
+[node name="Bloom" type="HBoxContainer" parent="UI/Settings"]
+margin_top = 174.0
+margin_right = 1342.0
+margin_bottom = 231.0
+custom_constants/separation = 30
+__meta__ = {
+"_edit_group_": true
+}
+
+[node name="Label" type="Label" parent="UI/Settings/Bloom"]
+margin_right = 400.0
+margin_bottom = 57.0
+rect_min_size = Vector2( 400, 0 )
+size_flags_vertical = 1
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+text = "Bloom:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="High" type="Button" parent="UI/Settings/Bloom"]
+margin_left = 430.0
+margin_right = 714.0
+margin_bottom = 57.0
+size_flags_horizontal = 3
+toggle_mode = true
+pressed = true
+group = SubResource( 19 )
+text = "High"
+
+[node name="Low" type="Button" parent="UI/Settings/Bloom"]
+margin_left = 744.0
+margin_right = 1028.0
+margin_bottom = 57.0
+size_flags_horizontal = 3
+toggle_mode = true
+group = SubResource( 19 )
+text = "Low"
+
+[node name="Disabled" type="Button" parent="UI/Settings/Bloom"]
+margin_left = 1058.0
+margin_right = 1342.0
+margin_bottom = 57.0
+size_flags_horizontal = 3
+toggle_mode = true
+group = SubResource( 19 )
 text = "Disabled"
 
 [node name="Resolution" type="HBoxContainer" parent="UI/Settings"]

--- a/menu/settings.gd
+++ b/menu/settings.gd
@@ -19,6 +19,12 @@ enum SSAOQuality {
 	HIGH = 2
 }
 
+enum BloomQuality {
+	DISABLED = 0
+	LOW = 1
+	HIGH = 2
+}
+
 enum Resolution {
 	RES_540 = 0
 	RES_720 = 1
@@ -29,6 +35,7 @@ enum Resolution {
 var gi_quality = GIQuality.LOW
 var aa_quality = AAQuality.AA_2X
 var ssao_quality = SSAOQuality.DISABLED
+var bloom_quality = BloomQuality.HIGH
 var resolution = Resolution.NATIVE
 var fullscreen = true
 
@@ -48,20 +55,23 @@ func load_settings():
 	if error:
 		print("There are no settings to load.")
 		return
-	
+
 	var d = parse_json(f.get_as_text())
 	if typeof(d) != TYPE_DICTIONARY:
 		return
-	
+
 	if "gi" in d:
 		gi_quality = int(d.gi)
-	
+
 	if "aa" in d:
 		aa_quality = int(d.aa)
-	
+
 	if "ssao" in d:
 		ssao_quality = int(d.ssao)
-	
+
+	if "bloom" in d:
+		bloom_quality = int(d.bloom)
+
 	if "resolution" in d:
 		resolution = int(d.resolution)
 
@@ -74,5 +84,5 @@ func save_settings():
 	var error = f.open("user://settings.json", File.WRITE)
 	assert(not error)
 
-	var d = { "gi":gi_quality, "aa":aa_quality, "ssao":ssao_quality, "resolution":resolution, "fullscreen":fullscreen }
+	var d = { "gi":gi_quality, "aa":aa_quality, "ssao":ssao_quality, "bloom":bloom_quality, "resolution":resolution, "fullscreen":fullscreen }
 	f.store_line(to_json(d))


### PR DESCRIPTION
The default level is High, which is equivalent to the previous glow setting used (bicubic upscaling enabled).

Low keeps glow enabled but disables bicubic upscaling. Disabled disables glow entirely.

The setting is called "bloom" as it's a more common term in gaming, even though the Environment parameter is called "glow".