### PR TITLE
Add commas and tweak scripts for better compatibility with Godot 4

### DIFF
--- a/enemies/red_robot/red_robot.gd
+++ b/enemies/red_robot/red_robot.gd
@@ -175,7 +175,7 @@ func _physics_process(delta):
 			var to_cannon_local = ray_mesh.global_transform.xform_inv(player.global_transform.origin + Vector3.UP)
 			var h_angle = rad2deg(atan2( to_cannon_local.x, -to_cannon_local.z ))
 			var v_angle = rad2deg(atan2( to_cannon_local.y, -to_cannon_local.z ))
-			var blend_pos = animation_tree["parameters/aim/blend_position"]
+			var blend_pos = animation_tree.get("parameters/aim/blend_position")
 			var h_motion = BLEND_AIM_SPEED * delta * -h_angle
 			blend_pos.x += h_motion
 			blend_pos.x = clamp(blend_pos.x, -1, 1)

--- a/level/level.gd
+++ b/level/level.gd
@@ -17,17 +17,19 @@ func _ready():
 		$ReflectionProbes.show()
 
 	if Settings.aa_quality == Settings.AAQuality.AA_8X:
-		get_node("/root").msaa = Viewport.MSAA_8X
+		get_viewport().msaa = Viewport.MSAA_8X
 	elif Settings.aa_quality == Settings.AAQuality.AA_4X:
-		get_node("/root").msaa = Viewport.MSAA_4X
+		get_viewport().msaa = Viewport.MSAA_4X
 	elif Settings.aa_quality == Settings.AAQuality.AA_2X:
-		get_node("/root").msaa = Viewport.MSAA_2X
+		get_viewport().msaa = Viewport.MSAA_2X
 	else:
-		get_node("/root").msaa = Viewport.MSAA_DISABLED
+		get_viewport().msaa = Viewport.MSAA_DISABLED
 
 	if Settings.ssao_quality == Settings.SSAOQuality.HIGH:
+		world_environment.environment.ssao_enabled = true
 		world_environment.environment.ssao_quality = world_environment.environment.SSAO_QUALITY_HIGH
 	elif Settings.ssao_quality == Settings.SSAOQuality.LOW:
+		world_environment.environment.ssao_enabled = true
 		world_environment.environment.ssao_quality = world_environment.environment.SSAO_QUALITY_LOW
 	else:
 		world_environment.environment.ssao_enabled = false
@@ -42,16 +44,17 @@ func _ready():
 		world_environment.environment.glow_enabled = false
 		world_environment.environment.glow_bicubic_upscale = false
 
+	var window_size = OS.window_size
 	if Settings.resolution == Settings.Resolution.NATIVE:
 		pass
 	elif Settings.resolution == Settings.Resolution.RES_1080:
-		var minsize = Vector2(OS.window_size.x * 1080 / OS.window_size.y, 1080.0)
+		var minsize = Vector2(window_size.x * 1080 / window_size.y, 1080.0)
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
 	elif Settings.resolution == Settings.Resolution.RES_720:
-		var minsize = Vector2(OS.window_size.x * 720 / OS.window_size.y, 720.0)
+		var minsize = Vector2(window_size.x * 720 / window_size.y, 720.0)
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
 	elif Settings.resolution == Settings.Resolution.RES_540:
-		var minsize = Vector2(OS.window_size.x * 540 / OS.window_size.y, 540.0)
+		var minsize = Vector2(window_size.x * 540 / window_size.y, 540.0)
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
 
 

--- a/menu/settings.gd
+++ b/menu/settings.gd
@@ -1,35 +1,35 @@
 extends Node
 
 enum GIQuality {
-	DISABLED = 0
-	LOW = 1
-	HIGH = 2
+	DISABLED = 0,
+	LOW = 1,
+	HIGH = 2,
 }
 
 enum AAQuality {
-	DISABLED = 0
-	AA_2X = 1
-	AA_4X = 2
-	AA_8X = 3
+	DISABLED = 0,
+	AA_2X = 1,
+	AA_4X = 2,
+	AA_8X = 3,
 }
 
 enum SSAOQuality {
-	DISABLED = 0
-	LOW = 1
-	HIGH = 2
+	DISABLED = 0,
+	LOW = 1,
+	HIGH = 2,
 }
 
 enum BloomQuality {
-	DISABLED = 0
-	LOW = 1
-	HIGH = 2
+	DISABLED = 0,
+	LOW = 1,
+	HIGH = 2,
 }
 
 enum Resolution {
-	RES_540 = 0
-	RES_720 = 1
-	RES_1080 = 2
-	NATIVE = 3
+	RES_540 = 0,
+	RES_720 = 1,
+	RES_1080 = 2,
+	NATIVE = 3,
 }
 
 var gi_quality = GIQuality.LOW


### PR DESCRIPTION
I copied a few of the tweaks from #88. These improve 4.0 compatibility, but still work great in 3.2.