### PR TITLE
Update README for the new 3.2 branch

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,7 +15,7 @@ used to create this scene were kindly provided by GameTextures.com
 
 ************************************************************************
 
-All code Copyright (c) 2018-2020 Juan Linietsky, Godot Engine contributors.
+All code Copyright (c) 2018-2021 Juan Linietsky, Godot Engine contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
 
 ## Godot versions
 
-- The [`master`](https://github.com/godotengine/tps-demo) branch is compatible with the latest stable Godot version (currently 3.2.x that is at least 3.2.2).
+- The [`master`](https://github.com/godotengine/tps-demo) branch is compatible with the latest stable Godot version (currently 3.3.x).
 - If you are using an older version of Godot, use the appropriate branch for your Godot version:
 
+  - [`3.2`](https://github.com/godotengine/tps-demo/tree/3.2) branch
+  for Godot 3.2.2 or 3.2.3.
   - [`3.2.1`](https://github.com/godotengine/tps-demo/tree/3.2.1) branch
   for Godot 3.2.0 or 3.2.1.
   - [`3.1`](https://github.com/godotengine/tps-demo/tree/3.1) branch
@@ -30,6 +32,17 @@ Those branches have instructions for Git LFS in their README files.
 You need [Godot Engine](https://godotengine.org) to run this demo project.
 Download the latest stable version [from the website](https://godotengine.org/download/),
 or [build it from source](https://github.com/godotengine/godot).
+
+You can either download from the Godot Asset Library, clone this repository, or
+[download a ZIP archive](https://github.com/godotengine/tps-demo/archive/master.zip).
+
+## Useful links
+
+- [Main website](https://godotengine.org)
+- [Source code](https://github.com/godotengine/godot)
+- [Documentation](http://docs.godotengine.org)
+- [Community hub](https://godotengine.org/community)
+- [Other demos](https://github.com/godotengine/godot-demo-projects)
 
 ## License
 


### PR DESCRIPTION
This PR updates the README for Godot 3.3 and a few other misc things.

After this PR, there will be a 3.2 branch, and the master branch of the TPS demo will be targeting Godot 3.3.x.