### PR TITLE
[3.x] Allow falling back to GLES2

### DIFF
--- a/level/geometry/environment.tres
+++ b/level/geometry/environment.tres
@@ -1,7 +1,15 @@
-[gd_resource type="Environment" format=2]
+[gd_resource type="Environment" load_steps=2 format=2]
+
+[sub_resource type="ProceduralSky" id=1]
+sky_top_color = Color( 0.65098, 0.498039, 0.356863, 1 )
+sky_horizon_color = Color( 0.101961, 0.0784314, 0.054902, 1 )
+ground_bottom_color = Color( 0.101961, 0.0784314, 0.054902, 1 )
+ground_horizon_color = Color( 0.101961, 0.0784314, 0.054902, 1 )
+sun_energy = 0.0
 
 [resource]
 background_mode = 1
+background_sky = SubResource( 1 )
 ambient_light_color = Color( 0.258824, 0.203922, 0.152941, 1 )
 ambient_light_sky_contribution = 0.0
 fog_enabled = true

--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -8,6 +8,7 @@ signal replace_main_scene
 signal quit # Useless, but needed as there is no clean way to check if a node exposes a signal
 
 onready var ui = $UI
+onready var gles2_fallback = ui.get_node(@"GLES2Fallback")
 onready var main = ui.get_node(@"Main")
 onready var play_button = main.get_node(@"Play")
 onready var settings_button = main.get_node(@"Settings")
@@ -63,6 +64,13 @@ onready var loading_done_timer = loading.get_node(@"DoneTimer")
 
 func _ready():
 	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_2D, SceneTree.STRETCH_ASPECT_EXPAND, Vector2(1920, 1080))
+
+	if OS.get_current_video_driver() == OS.VIDEO_DRIVER_GLES2:
+		gles2_fallback.visible = true
+		# GI and SSAO are not supported in GLES2.
+		gi_menu.visible = false
+		ssao_menu.visible = false
+
 	play_button.grab_focus()
 	var sound_effects = $BackgroundCache/RedRobot/SoundEffects
 	for child in sound_effects.get_children():

--- a/menu/menu.tscn
+++ b/menu/menu.tscn
@@ -201,6 +201,18 @@ anchor_right = 1.00107
 anchor_bottom = 1.0
 theme = SubResource( 9 )
 
+[node name="GLES2Fallback" type="Label" parent="UI"]
+visible = false
+margin_left = 97.9495
+margin_top = 200.0
+margin_right = 837.949
+margin_bottom = 253.0
+custom_colors/font_color = Color( 1, 0.870588, 0.356863, 1 )
+text = "GLES2 fallback (degraded graphics quality)"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [node name="Main" type="Control" parent="UI"]
 anchor_left = -0.000673103
 anchor_top = -0.00189865

--- a/player/bullet/bullet.tscn
+++ b/player/bullet/bullet.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=63 format=2]
+[gd_scene load_steps=57 format=2]
 
 [ext_resource path="res://player/bullet/bullet.gd" type="Script" id=1]
 [ext_resource path="res://effects_shared/BlastMesh_Sphere.mesh" type="ArrayMesh" id=2]
@@ -373,26 +373,6 @@ scale_curve = SubResource( 40 )
 radius = 0.3
 height = 0.6
 
-[sub_resource type="Gradient" id=43]
-colors = PoolColorArray( 1, 1, 1, 1, 1, 1, 1, 0 )
-
-[sub_resource type="GradientTexture" id=44]
-gradient = SubResource( 43 )
-
-[sub_resource type="Curve" id=45]
-max_value = 4.0
-_data = [ Vector2( 0.150987, 4 ), 0.0, 0.0, 0, 0, Vector2( 1, 0.6936 ), 0.0, 0.0, 0, 0 ]
-
-[sub_resource type="CurveTexture" id=46]
-curve = SubResource( 45 )
-
-[sub_resource type="ParticlesMaterial" id=47]
-spread = 180.0
-gravity = Vector3( 0, -1, 0 )
-scale = 0.3
-scale_curve = SubResource( 46 )
-color_ramp = SubResource( 44 )
-
 [sub_resource type="SpatialMaterial" id=48]
 flags_transparent = true
 vertex_color_use_as_albedo = true
@@ -411,38 +391,24 @@ height = 0.2
 radial_segments = 5
 rings = 3
 
-[sub_resource type="Gradient" id=50]
-colors = PoolColorArray( 1, 1, 1, 1, 0, 0.0313726, 0.501961, 0.752941 )
+[sub_resource type="Curve" id=45]
+max_value = 4.0
+_data = [ Vector2( 0.150987, 4 ), 0.0, 0.0, 0, 0, Vector2( 1, 0.6936 ), 0.0, 0.0, 0, 0 ]
 
-[sub_resource type="GradientTexture" id=51]
-gradient = SubResource( 50 )
-width = 128
-
-[sub_resource type="Curve" id=52]
-_data = [ Vector2( 0, 0 ), 0.0, 0.0, 0, 0, Vector2( 0.417722, 1 ), 0.0, 0.0, 0, 0, Vector2( 1, 0 ), 0.0, 0.0, 0, 0 ]
-
-[sub_resource type="CurveTexture" id=53]
-width = 128
-curve = SubResource( 52 )
-
-[sub_resource type="ParticlesMaterial" id=54]
-emission_shape = 1
-emission_sphere_radius = 0.1
-flag_align_y = true
-direction = Vector3( 0, 0, -1 )
-spread = 0.0
-gravity = Vector3( 0, 0, 0 )
-initial_velocity = 9.0
-damping = 9.0
-scale = 0.3
-scale_curve = SubResource( 53 )
-color_ramp = SubResource( 51 )
+[sub_resource type="Gradient" id=43]
+colors = PoolColorArray( 1, 1, 1, 1, 1, 1, 1, 0 )
 
 [sub_resource type="SphereMesh" id=55]
 radius = 0.05
 height = 0.3
 radial_segments = 4
 rings = 4
+
+[sub_resource type="Curve" id=52]
+_data = [ Vector2( 0, 0 ), 0.0, 0.0, 0, 0, Vector2( 0.417722, 1 ), 0.0, 0.0, 0, 0, Vector2( 1, 0 ), 0.0, 0.0, 0, 0 ]
+
+[sub_resource type="Gradient" id=50]
+colors = PoolColorArray( 1, 1, 1, 1, 0, 0.0313726, 0.501961, 0.752941 )
 
 [node name="Bullet" type="KinematicBody"]
 collision_layer = 0
@@ -545,19 +511,33 @@ mesh = ExtResource( 2 )
 
 [node name="BulletBody" type="Spatial" parent="."]
 
-[node name="MainBody" type="Particles" parent="BulletBody"]
+[node name="MainBody" type="CPUParticles" parent="BulletBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00988865, 0, 0 )
 cast_shadow = 0
 amount = 100
 lifetime = 0.1
 local_coords = false
-process_material = SubResource( 47 )
-draw_pass_1 = SubResource( 49 )
+mesh = SubResource( 49 )
+spread = 180.0
+gravity = Vector3( 0, -1, 0 )
+scale_amount = 0.3
+scale_amount_curve = SubResource( 45 )
+color_ramp = SubResource( 43 )
 
-[node name="Trail" type="Particles" parent="BulletBody"]
+[node name="Trail" type="CPUParticles" parent="BulletBody"]
 material_override = ExtResource( 9 )
 cast_shadow = 0
 amount = 10
 local_coords = false
-process_material = SubResource( 54 )
-draw_pass_1 = SubResource( 55 )
+mesh = SubResource( 55 )
+emission_shape = 1
+emission_sphere_radius = 0.1
+flag_align_y = true
+direction = Vector3( 0, 0, -1 )
+spread = 0.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 9.0
+damping = 9.0
+scale_amount = 0.3
+scale_amount_curve = SubResource( 52 )
+color_ramp = SubResource( 50 )

--- a/project.godot
+++ b/project.godot
@@ -218,6 +218,7 @@ common/physics_interpolation=true
 
 [rendering]
 
+quality/driver/fallback_to_gles2=true
 vram_compression/import_etc2=false
 quality/shadow_atlas/size=2048
 quality/shading/use_physical_light_attenuation=true


### PR DESCRIPTION
This allows running the TPS demo on a greater range of devices and platforms, while also allowing its use for GLES2 renderer testing.

Several automatic adjustments are made to ensure it looks as good as possible (within the limitations of GLES2 and the lack of baked lightmaps).

Some particles are currently missing and would need CPUParticles fallbacks to be added to become visible again.

**Edit:** Bullet bodies/trails are now visible in GLES2 as this PR converts them to CPUParticles. They look identical to before in GLES3.
Bullet explosions are still missing, but they use custom particle shaders so a complete rewrite would be required.

To test this locally, start the project with the `--video-driver GLES2` command line argument (or add `--video-driver GLES2` to the **Main Run Args** project setting).

![2022-01-10_18 57 43](https://user-images.githubusercontent.com/180032/148816217-4c26b0bb-b047-42b9-9760-6f054be6d19f.png)