### PR TITLE
Enable asynchronous shader compilation and caching

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -221,5 +221,6 @@ common/physics_interpolation=true
 vram_compression/import_etc2=false
 quality/shadow_atlas/size=2048
 quality/shading/use_physical_light_attenuation=true
+gles3/shaders/shader_compilation_mode=2
 quality/filters/msaa=2
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
~~Do not merge until Godot 3.5.1 is released, as it includes https://github.com/godotengine/godot/pull/64096 which is required for this PR to work well.~~
**Edit:** 3.5.1 is now released, so this can be merged :slightly_smiling_face: 

This mitigates shader compilation stutter, especially after an initial playthrough thanks to caching.

This requires Godot 3.5 or later to have an effect.