### PR TITLE
Enable physical light attenuation

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -219,6 +219,7 @@ toggle_debug={
 
 vram_compression/import_etc2=false
 quality/shadow_atlas/size=2048
+quality/shading/use_physical_light_attenuation=true
 quality/filters/msaa=2
 environment/default_environment="res://default_env.tres"
 quality/dynamic_fonts/use_oversampling=false


### PR DESCRIPTION
This uses a more realistic light attenuation model, similar to the one used in 4.0.alpha.

The effect isn't very noticeable on the scene, except when firing the weapon.