### PR TITLE
Disable shadow casting for short-lived effects

### DIFF
--- a/enemies/red_robot/laser/impact_effect/impact_effect.tscn
+++ b/enemies/red_robot/laser/impact_effect/impact_effect.tscn
@@ -169,6 +169,7 @@ anims/blast = SubResource( 1 )
 
 [node name="Blast" type="CPUParticles" parent="."]
 material_override = SubResource( 2 )
+cast_shadow = 0
 emitting = false
 amount = 1
 lifetime = 0.3
@@ -180,6 +181,7 @@ color_ramp = SubResource( 4 )
 
 [node name="LightRays" type="CPUParticles" parent="."]
 material_override = SubResource( 5 )
+cast_shadow = 0
 emitting = false
 amount = 40
 lifetime = 0.2
@@ -202,6 +204,7 @@ hue_variation_random = 0.78
 
 [node name="BlastCenter" type="CPUParticles" parent="."]
 material_override = SubResource( 7 )
+cast_shadow = 0
 emitting = false
 amount = 1
 lifetime = 0.2
@@ -213,6 +216,7 @@ scale_amount_curve = SubResource( 9 )
 
 [node name="ExplosionEmbers" type="CPUParticles" parent="."]
 material_override = ExtResource( 8 )
+cast_shadow = 0
 emitting = false
 amount = 50
 one_shot = true
@@ -229,6 +233,7 @@ color_ramp = SubResource( 12 )
 
 [node name="SmokeParticle" type="CPUParticles" parent="."]
 material_override = SubResource( 13 )
+cast_shadow = 0
 emitting = false
 amount = 20
 one_shot = true

--- a/enemies/red_robot/parts/part_disappear_effect/part_disappear.tscn
+++ b/enemies/red_robot/parts/part_disappear_effect/part_disappear.tscn
@@ -43,6 +43,7 @@ _data = [ Vector2( 0, 0 ), 0.0, 0.37234, 0, 0, Vector2( 0.462338, 0.981818 ), 5.
 
 [node name="PartDisappearPuff" type="CPUParticles"]
 material_override = SubResource( 1 )
+cast_shadow = 0
 emitting = false
 lifetime = 1.5
 one_shot = true
@@ -64,6 +65,7 @@ script = ExtResource( 3 )
 
 [node name="MiniBlasts" type="CPUParticles" parent="."]
 material_override = SubResource( 5 )
+cast_shadow = 0
 emitting = false
 amount = 16
 lifetime = 0.3

--- a/enemies/red_robot/red_robot.tscn
+++ b/enemies/red_robot/red_robot.tscn
@@ -116,7 +116,7 @@ uniform_name = "Displacement"
 
 [sub_resource type="VisualShader" id=22]
 code = "shader_type spatial;
-render_mode specular_schlick_ggx;
+render_mode specular_schlick_ggx, async_visible;
 
 uniform sampler2D noise;
 uniform float Displacement;
@@ -400,7 +400,7 @@ nodes/hit3/position = Vector2( 980, 240 )
 nodes/output/position = Vector2( 1180, 200 )
 nodes/state/node = SubResource( 51 )
 nodes/state/position = Vector2( 60, 100 )
-node_connections = [ "state", 0, "Animation", "state", 1, "Animation 3", "state", 2, "Animation 2", "state", 3, "Animation 4", "output", 0, "hit3", "aiming", 0, "state", "aiming", 1, "aim", "hit1", 0, "aiming", "hit1", 1, "Animation 5", "hit2", 0, "hit1", "hit2", 1, "Animation 6", "hit3", 0, "hit2", "hit3", 1, "Animation 7" ]
+node_connections = [ "state", 0, "Animation", "state", 1, "Animation 3", "state", 2, "Animation 2", "state", 3, "Animation 4", "output", 0, "hit3", "hit2", 0, "hit1", "hit2", 1, "Animation 6", "aiming", 0, "state", "aiming", 1, "aim", "hit1", 0, "aiming", "hit1", 1, "Animation 5", "hit3", 0, "hit2", "hit3", 1, "Animation 7" ]
 
 [sub_resource type="SphereShape" id=53]
 radius = 1.11815
@@ -771,7 +771,7 @@ script = ExtResource( 1 )
 bones/14/bound_children = [ NodePath("RayFrom") ]
 
 [node name="RayFrom" type="BoneAttachment" parent="RedRobotModel/Armature/Skeleton" index="4"]
-transform = Transform( -0.997439, -0.070985, -0.00878045, -0.0710157, 0.99747, 0.00323016, 0.00852894, 0.00384544, -0.999956, -0.149183, 1.9902, 0.191941 )
+transform = Transform( -0.999676, 0.0252579, 0.00304912, 0.0252842, 0.99964, 0.00893937, -0.00282223, 0.00901357, -0.999955, 0.0411851, 2.0763, 0.18828 )
 bone_name = "CannonAnimRecoil"
 
 [node name="Circle" type="MeshInstance" parent="RedRobotModel/Armature/Skeleton/RayFrom"]
@@ -789,6 +789,7 @@ material/0 = ExtResource( 4 )
 [node name="BuildupParticles" type="CPUParticles" parent="RedRobotModel/Armature/Skeleton/RayFrom"]
 transform = Transform( 1, 3.70164e-10, 5.82077e-11, 3.66526e-10, 1, 9.31323e-10, 0, 1.86265e-09, 1, -1.39698e-09, 0, -1.47648 )
 material_override = ExtResource( 7 )
+cast_shadow = 0
 emitting = false
 amount = 64
 lifetime = 0.4
@@ -810,6 +811,7 @@ hue_variation_random = 0.87
 
 [node name="LaserEmber" type="CPUParticles" parent="RedRobotModel/Armature/Skeleton/RayFrom"]
 transform = Transform( 1, 7.30506e-09, 4.65661e-10, 0, 1, 0, 0, 3.72529e-09, 1, -7.45058e-09, 0.0332088, -10.283 )
+cast_shadow = 0
 emitting = false
 amount = 200
 lifetime = 2.0
@@ -836,6 +838,7 @@ anim_offset_random = 1.0
 [node name="LaserCenter" type="CPUParticles" parent="RedRobotModel/Armature/Skeleton/RayFrom"]
 transform = Transform( 1, 3.72893e-10, 1.74623e-10, 3.66526e-10, 1, 4.65661e-09, 0, 5.58794e-09, 1, -8.3819e-09, 0, -1.47136 )
 material_override = SubResource( 25 )
+cast_shadow = 0
 emitting = false
 amount = 1
 lifetime = 1.5
@@ -847,6 +850,7 @@ scale_amount_curve = SubResource( 27 )
 [node name="Smoke" type="CPUParticles" parent="RedRobotModel/Armature/Skeleton/RayFrom"]
 transform = Transform( 1, 1.16415e-10, -4.0518e-10, 3.66526e-10, -4.19095e-08, -1, 0, 1, -4.65661e-08, -6.51926e-09, -1.43051e-06, -1.34189 )
 material_override = SubResource( 31 )
+cast_shadow = 0
 emitting = false
 amount = 3
 lifetime = 1.5
@@ -928,6 +932,7 @@ script = ExtResource( 24 )
 [node name="StaticParticle" type="CPUParticles" parent="Death/PartShield1"]
 transform = Transform( 1, 0, 0, 0, 0.965835, 0.259156, 0, -0.259156, 0.965835, 0, 0, 0 )
 material_override = ExtResource( 8 )
+cast_shadow = 0
 amount = 3
 lifetime = 0.5
 randomness = 0.35
@@ -972,6 +977,7 @@ script = ExtResource( 24 )
 [node name="StaticParticle" type="CPUParticles" parent="Death/PartShield2"]
 transform = Transform( 1, 0, 0, 0, 0.965835, 0.259156, 0, -0.259156, 0.965835, 0, 0, 0 )
 material_override = ExtResource( 8 )
+cast_shadow = 0
 amount = 3
 lifetime = 0.5
 randomness = 0.35
@@ -1017,6 +1023,7 @@ script = ExtResource( 24 )
 [node name="StaticParticle3" type="CPUParticles" parent="Death/PartHead"]
 transform = Transform( 1, 0, 0, 0, 0.965835, 0.259156, 0, -0.259156, 0.965835, 0, 0, 0 )
 material_override = ExtResource( 8 )
+cast_shadow = 0
 amount = 3
 lifetime = 0.5
 randomness = 0.35
@@ -1054,6 +1061,7 @@ anims/kaboom = SubResource( 67 )
 [node name="DetachSpark1" type="CPUParticles" parent="Death"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.803977, 0.987653, 0 )
 material_override = SubResource( 68 )
+cast_shadow = 0
 emitting = false
 amount = 50
 lifetime = 0.4
@@ -1071,6 +1079,7 @@ color = Color( 0, 0.976471, 1, 1 )
 [node name="DetachSpark2" type="CPUParticles" parent="Death"]
 transform = Transform( -1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, -1.11386, 0.987653, 0 )
 material_override = SubResource( 68 )
+cast_shadow = 0
 emitting = false
 amount = 50
 lifetime = 0.4

--- a/player/bullet/bullet.tscn
+++ b/player/bullet/bullet.tscn
@@ -453,13 +453,11 @@ transform = Transform( 0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0 )
 visible = false
 cast_shadow = 0
 mesh = SubResource( 1 )
-material/0 = null
 
 [node name="OmniLight" type="OmniLight" parent="."]
 light_color = Color( 0, 1, 0.952941, 1 )
 light_energy = 0.778846
 light_bake_mode = 0
-shadow_enabled = true
 omni_range = 3.0
 omni_attenuation = 2.0
 omni_shadow_mode = 0
@@ -478,6 +476,7 @@ unit_size = 20.0
 
 [node name="BlastParticle" type="Particles" parent="Blast"]
 material_override = ExtResource( 4 )
+cast_shadow = 0
 emitting = false
 amount = 1
 lifetime = 0.6
@@ -487,6 +486,7 @@ draw_pass_1 = ExtResource( 2 )
 
 [node name="LightBlast" type="Particles" parent="Blast"]
 material_override = ExtResource( 5 )
+cast_shadow = 0
 emitting = false
 amount = 1
 lifetime = 0.15
@@ -496,6 +496,7 @@ draw_pass_1 = SubResource( 14 )
 
 [node name="BlastSparks" type="Particles" parent="Blast"]
 material_override = SubResource( 16 )
+cast_shadow = 0
 emitting = false
 amount = 10
 lifetime = 0.3
@@ -506,6 +507,7 @@ draw_pass_1 = SubResource( 22 )
 
 [node name="Smoke" type="Particles" parent="Blast"]
 material_override = SubResource( 23 )
+cast_shadow = 0
 emitting = false
 amount = 5
 lifetime = 1.5
@@ -516,6 +518,7 @@ draw_pass_1 = SubResource( 31 )
 
 [node name="LightParticle" type="Particles" parent="Blast"]
 material_override = SubResource( 32 )
+cast_shadow = 0
 emitting = false
 amount = 3
 lifetime = 0.8
@@ -526,6 +529,7 @@ draw_pass_1 = SubResource( 38 )
 
 [node name="InnerBlastLight" type="Particles" parent="Blast"]
 material_override = ExtResource( 9 )
+cast_shadow = 0
 emitting = false
 amount = 1
 lifetime = 0.2
@@ -536,13 +540,14 @@ draw_pass_1 = SubResource( 42 )
 [node name="MeshInstance2" type="MeshInstance" parent="."]
 visible = false
 material_override = ExtResource( 4 )
+cast_shadow = 0
 mesh = ExtResource( 2 )
-material/0 = null
 
 [node name="BulletBody" type="Spatial" parent="."]
 
 [node name="MainBody" type="Particles" parent="BulletBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00988865, 0, 0 )
+cast_shadow = 0
 amount = 100
 lifetime = 0.1
 local_coords = false
@@ -551,6 +556,7 @@ draw_pass_1 = SubResource( 49 )
 
 [node name="Trail" type="Particles" parent="BulletBody"]
 material_override = ExtResource( 9 )
+cast_shadow = 0
 amount = 10
 local_coords = false
 process_material = SubResource( 54 )

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -291,6 +291,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.4, 0 )
 [node name="ShootParticle" type="Particles" parent="PlayerModel/Robot_Skeleton/Skeleton/GunBone/ShootFrom"]
 transform = Transform( 1, 2.04891e-08, 0, 3.21306e-08, 1, 5.58794e-09, 0, 0, 1, 0, 0, 0 )
 material_override = ExtResource( 9 )
+cast_shadow = 0
 emitting = false
 amount = 10
 lifetime = 0.3
@@ -303,6 +304,7 @@ draw_pass_1 = SubResource( 2 )
 [node name="MuzzleFlash" type="Particles" parent="PlayerModel/Robot_Skeleton/Skeleton/GunBone/ShootFrom"]
 transform = Transform( 1, 0, -2.00234e-08, 1.21072e-08, -4.37722e-08, -1, -2.98023e-08, 1, -4.74975e-08, 0, 0, 0 )
 material_override = SubResource( 3 )
+cast_shadow = 0
 emitting = false
 amount = 1
 lifetime = 0.1


### PR DESCRIPTION
Can be merged independently of https://github.com/godotengine/tps-demo/pull/131.

This improves performance when the player or enemy fires their weapon, or when an enemy dies. This may also help reduce shader compilation stutter on the first playthrough (even when asynchronous compilation is enabled).

There is usually no noticeable visual difference.