### PR TITLE
Enable physics interpolation

### DIFF
--- a/level/forklift/flying_forklift.tscn
+++ b/level/forklift/flying_forklift.tscn
@@ -27,6 +27,7 @@ material = SubResource( 2 )
 colors = PoolColorArray( 0, 1, 0.976562, 1, 1, 1, 1, 0 )
 
 [node name="FlyingForklift" type="KinematicBody"]
+physics_interpolation_mode = 1
 script = ExtResource( 3 )
 
 [node name="FlyingForkliftModel" parent="." instance=ExtResource( 1 )]

--- a/level/geometry/scenes/core.tscn
+++ b/level/geometry/scenes/core.tscn
@@ -155,24 +155,24 @@ offsets = PoolRealArray( 0.381215, 0.61326, 0.994475 )
 colors = PoolColorArray( 1, 0.678431, 0, 1, 0.138889, 0.0944011, 0, 1, 0, 0, 0, 1 )
 
 [sub_resource type="CylinderShape" id=4]
-radius = 10.5
 height = 4.0
+radius = 10.5
 
 [sub_resource type="CylinderShape" id=5]
-radius = 11.0
 height = 3.6
+radius = 11.0
 
 [sub_resource type="CylinderShape" id=6]
-radius = 4.5
 height = 24.0
+radius = 4.5
 
 [sub_resource type="CylinderShape" id=7]
-radius = 10.0
 height = 11.0
+radius = 10.0
 
 [sub_resource type="CylinderShape" id=8]
-radius = 35.0
 height = 5.0
+radius = 35.0
 
 [sub_resource type="BoxShape" id=9]
 extents = Vector3( 40, 6, 40 )
@@ -208,9 +208,9 @@ color_ramp = SubResource( 3 )
 transform = Transform( 0.334226, 0, 0, 0, 0.334226, 0, 0, 0, 0.334226, 0, 0, 0 )
 material_override = SubResource( 15 )
 mesh = ExtResource( 7 )
-material/0 = null
 
 [node name="CPUParticles" type="CPUParticles" parent="Plasma"]
+physics_interpolation_mode = 1
 material_override = SubResource( 20 )
 amount = 3
 preprocess = 5.29
@@ -235,6 +235,7 @@ scale_amount_curve = SubResource( 21 )
 color_ramp = SubResource( 22 )
 
 [node name="CPUParticles2" type="CPUParticles" parent="Plasma"]
+physics_interpolation_mode = 1
 material_override = SubResource( 23 )
 amount = 5
 mesh = ExtResource( 12 )
@@ -249,6 +250,7 @@ scale_amount_curve = SubResource( 24 )
 color_ramp = SubResource( 25 )
 
 [node name="CPUParticles3" type="CPUParticles" parent="Plasma"]
+physics_interpolation_mode = 1
 material_override = SubResource( 23 )
 amount = 7
 explosiveness = 0.14

--- a/project.godot
+++ b/project.godot
@@ -214,6 +214,7 @@ toggle_debug={
 [physics]
 
 3d/physics_engine="Bullet"
+common/physics_interpolation=true
 
 [rendering]
 


### PR DESCRIPTION
Like https://github.com/godotengine/tps-demo/pull/130, this enables another new feature in 3.5.

Physics interpolation was disabled on the reactor core's particles as it caused visual glitches (and is not needed there anyway). It was also disabled on the flying forklift as it's actually moved in `_process` (the engine was printing warnings about it).

To test this, run the demo with the lowest possible settings and see if overall smoothness improves. Note that player/enemy animations are not interpolated (only their movement is), so they remain locked at their 60 Hz rate. In practice, this usually looks good enough. Still, I wonder how these can be interpolated too :slightly_smiling_face: 

cc @lawnjelly