### PR TITLE
Use the `expand` stretch aspect to support arbitrary aspect ratios

### DIFF
--- a/level/level.gd
+++ b/level/level.gd
@@ -49,13 +49,13 @@ func _ready():
 		pass
 	elif Settings.resolution == Settings.Resolution.RES_1080:
 		var minsize = Vector2(window_size.x * 1080 / window_size.y, 1080.0)
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_EXPAND, minsize)
 	elif Settings.resolution == Settings.Resolution.RES_720:
 		var minsize = Vector2(window_size.x * 720 / window_size.y, 720.0)
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_EXPAND, minsize)
 	elif Settings.resolution == Settings.Resolution.RES_540:
 		var minsize = Vector2(window_size.x * 540 / window_size.y, 540.0)
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, minsize)
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_EXPAND, minsize)
 
 
 func _input(event):

--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -54,7 +54,7 @@ onready var loading_progress = loading.get_node(@"Progress")
 onready var loading_done_timer = loading.get_node(@"DoneTimer")
 
 func _ready():
-	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_2D, SceneTree.STRETCH_ASPECT_KEEP, Vector2(1920, 1080))
+	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_2D, SceneTree.STRETCH_ASPECT_EXPAND, Vector2(1920, 1080))
 	play_button.grab_focus()
 	var sound_effects = $BackgroundCache/RedRobot/SoundEffects
 	for child in sound_effects.get_children():

--- a/project.godot
+++ b/project.godot
@@ -35,7 +35,7 @@ window/size/width=1920
 window/size/height=1080
 window/size/fullscreen=true
 window/stretch/mode="2d"
-window/stretch/aspect="keep_width"
+window/stretch/aspect="expand"
 
 [input]
 


### PR DESCRIPTION
The menu and game no longer have black bars when using an aspect ratio wider than 16:9. This works both with native and sub-native resolutions.

## Preview

### Native 2560×1080

![2022-08-06_06 44 49](https://user-images.githubusercontent.com/180032/183234429-b88a8690-e477-432b-9ec2-0f6e2b811375.png)

![2022-08-06_06 45 09](https://user-images.githubusercontent.com/180032/183234430-afcff2d2-5152-4405-973f-5f38043c4783.png)

### 5120×1080 with 540 resolution option

![2022-08-06_06 48 38](https://user-images.githubusercontent.com/180032/183234433-281cf37a-9fab-406f-83e7-425d8bc08390.png)