### PR TITLE
Enable font oversampling for better text rendering at high resolutions

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -221,4 +221,3 @@ vram_compression/import_etc2=false
 quality/shadow_atlas/size=2048
 quality/filters/msaa=2
 environment/default_environment="res://default_env.tres"
-quality/dynamic_fonts/use_oversampling=false


### PR DESCRIPTION
This feature is enabled by default in Godot 3.1 and later.

## Preview

*Click to view at full size.*

### Before

![2022-08-06_06 57 18](https://user-images.githubusercontent.com/180032/183234689-0c64b90e-37e9-4a88-b7c0-b692df2dac6d.png)

### After

![2022-08-06_06 57 31](https://user-images.githubusercontent.com/180032/183234691-bc07504e-6d4e-4f14-beaa-ddedee0aa9a3.png)