### PR TITLE
Add a setting to disable real-time light shadows

### DIFF
--- a/level/level.gd
+++ b/level/level.gd
@@ -25,6 +25,11 @@ func _ready():
 	else:
 		get_viewport().msaa = Viewport.MSAA_DISABLED
 
+	if not Settings.shadow_enabled:
+		# Disable shadows on all lights present on level load,
+		# reducing the number of draw calls significantly.
+		propagate_call("set", ["shadow_enabled", false])
+
 	if Settings.ssao_quality == Settings.SSAOQuality.HIGH:
 		world_environment.environment.ssao_enabled = true
 		world_environment.environment.ssao_quality = world_environment.environment.SSAO_QUALITY_HIGH

--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -29,6 +29,10 @@ onready var aa_4x = aa_menu.get_node(@"4X")
 onready var aa_2x = aa_menu.get_node(@"2X")
 onready var aa_disabled = aa_menu.get_node(@"Disabled")
 
+onready var shadow_menu = settings_menu.get_node(@"Shadow")
+onready var shadow_enabled = shadow_menu.get_node(@"Enabled")
+onready var shadow_disabled = shadow_menu.get_node(@"Disabled")
+
 onready var ssao_menu = settings_menu.get_node(@"SSAO")
 onready var ssao_high = ssao_menu.get_node(@"High")
 onready var ssao_low = ssao_menu.get_node(@"Low")
@@ -124,6 +128,11 @@ func _on_settings_pressed():
 	elif Settings.aa_quality == Settings.AAQuality.DISABLED:
 		aa_disabled.pressed = true
 
+	if Settings.shadow_enabled:
+		shadow_enabled.pressed = true
+	else:
+		shadow_disabled.pressed = true
+
 	if Settings.ssao_quality == Settings.SSAOQuality.HIGH:
 		ssao_high.pressed = true
 	elif Settings.ssao_quality == Settings.SSAOQuality.LOW:
@@ -177,6 +186,8 @@ func _on_apply_pressed():
 		Settings.aa_quality = Settings.AAQuality.AA_2X
 	elif aa_disabled.pressed:
 		Settings.aa_quality = Settings.AAQuality.DISABLED
+
+	Settings.shadow_enabled = shadow_enabled.pressed
 
 	if ssao_high.pressed:
 		Settings.ssao_quality = Settings.SSAOQuality.HIGH

--- a/menu/menu.tscn
+++ b/menu/menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=42 format=2]
+[gd_scene load_steps=43 format=2]
 
 [ext_resource path="res://menu/menu.gd" type="Script" id=1]
 [ext_resource path="res://menu/experiment.hdr" type="Texture" id=2]
@@ -91,6 +91,8 @@ Label/styles/normal = null
 [sub_resource type="ButtonGroup" id=10]
 
 [sub_resource type="ButtonGroup" id=11]
+
+[sub_resource type="ButtonGroup" id=22]
 
 [sub_resource type="ButtonGroup" id=12]
 
@@ -196,9 +198,6 @@ anchor_left = 0.00106799
 anchor_right = 1.00107
 anchor_bottom = 1.0
 theme = SubResource( 9 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Main" type="Control" parent="UI"]
 anchor_left = -0.000673103
@@ -246,9 +245,9 @@ texture_hover = ExtResource( 12 )
 [node name="Settings" type="VBoxContainer" parent="UI"]
 visible = false
 anchor_left = 0.109896
-anchor_top = 0.32037
+anchor_top = 0.268518
 anchor_right = 0.808854
-anchor_bottom = 0.785185
+anchor_bottom = 0.931481
 custom_constants/separation = 30
 __meta__ = {
 "_edit_use_anchors_": true
@@ -329,7 +328,7 @@ text = "8x"
 
 [node name="4X" type="Button" parent="UI/Settings/AA"]
 margin_left = 665.0
-margin_right = 870.0
+margin_right = 871.0
 margin_bottom = 57.0
 size_flags_horizontal = 3
 toggle_mode = true
@@ -337,8 +336,8 @@ group = SubResource( 11 )
 text = "4x"
 
 [node name="2X" type="Button" parent="UI/Settings/AA"]
-margin_left = 900.0
-margin_right = 1105.0
+margin_left = 901.0
+margin_right = 1106.0
 margin_bottom = 57.0
 size_flags_horizontal = 3
 toggle_mode = true
@@ -346,7 +345,7 @@ group = SubResource( 11 )
 text = "2x"
 
 [node name="Disabled" type="Button" parent="UI/Settings/AA"]
-margin_left = 1135.0
+margin_left = 1136.0
 margin_right = 1342.0
 margin_bottom = 57.0
 size_flags_horizontal = 3
@@ -354,10 +353,46 @@ toggle_mode = true
 group = SubResource( 11 )
 text = "Disabled"
 
-[node name="SSAO" type="HBoxContainer" parent="UI/Settings"]
+[node name="Shadow" type="HBoxContainer" parent="UI/Settings"]
 margin_top = 174.0
 margin_right = 1342.0
 margin_bottom = 231.0
+custom_constants/separation = 30
+
+[node name="Label" type="Label" parent="UI/Settings/Shadow"]
+margin_top = 2.0
+margin_right = 400.0
+margin_bottom = 55.0
+rect_min_size = Vector2( 400, 0 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+text = "Shadow Mapping:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Enabled" type="Button" parent="UI/Settings/Shadow"]
+margin_left = 430.0
+margin_right = 871.0
+margin_bottom = 57.0
+size_flags_horizontal = 3
+toggle_mode = true
+pressed = true
+group = SubResource( 22 )
+text = "Enabled"
+
+[node name="Disabled" type="Button" parent="UI/Settings/Shadow"]
+margin_left = 901.0
+margin_right = 1342.0
+margin_bottom = 57.0
+size_flags_horizontal = 3
+toggle_mode = true
+group = SubResource( 22 )
+text = "Disabled"
+
+[node name="SSAO" type="HBoxContainer" parent="UI/Settings"]
+margin_top = 261.0
+margin_right = 1342.0
+margin_bottom = 318.0
 custom_constants/separation = 30
 __meta__ = {
 "_edit_group_": true
@@ -403,9 +438,9 @@ group = SubResource( 12 )
 text = "Disabled"
 
 [node name="Bloom" type="HBoxContainer" parent="UI/Settings"]
-margin_top = 174.0
+margin_top = 348.0
 margin_right = 1342.0
-margin_bottom = 231.0
+margin_bottom = 405.0
 custom_constants/separation = 30
 __meta__ = {
 "_edit_group_": true
@@ -451,9 +486,9 @@ group = SubResource( 13 )
 text = "Disabled"
 
 [node name="Resolution" type="HBoxContainer" parent="UI/Settings"]
-margin_top = 261.0
+margin_top = 435.0
 margin_right = 1342.0
-margin_bottom = 318.0
+margin_bottom = 492.0
 custom_constants/separation = 30
 __meta__ = {
 "_edit_group_": true
@@ -482,7 +517,7 @@ text = "Native"
 
 [node name="1080" type="Button" parent="UI/Settings/Resolution"]
 margin_left = 665.0
-margin_right = 870.0
+margin_right = 871.0
 margin_bottom = 57.0
 size_flags_horizontal = 3
 toggle_mode = true
@@ -490,8 +525,8 @@ group = SubResource( 14 )
 text = "1080"
 
 [node name="720" type="Button" parent="UI/Settings/Resolution"]
-margin_left = 900.0
-margin_right = 1105.0
+margin_left = 901.0
+margin_right = 1106.0
 margin_bottom = 57.0
 size_flags_horizontal = 3
 toggle_mode = true
@@ -499,7 +534,7 @@ group = SubResource( 14 )
 text = "720"
 
 [node name="540" type="Button" parent="UI/Settings/Resolution"]
-margin_left = 1135.0
+margin_left = 1136.0
 margin_right = 1342.0
 margin_bottom = 57.0
 size_flags_horizontal = 3
@@ -508,9 +543,9 @@ group = SubResource( 14 )
 text = "540"
 
 [node name="Fullscreen" type="HBoxContainer" parent="UI/Settings"]
-margin_top = 348.0
+margin_top = 522.0
 margin_right = 1342.0
-margin_bottom = 405.0
+margin_bottom = 579.0
 custom_constants/separation = 30
 
 [node name="Label" type="Label" parent="UI/Settings/Fullscreen"]
@@ -545,15 +580,15 @@ text = "No"
 
 [node name="HSeparator" type="HSeparator" parent="UI/Settings"]
 modulate = Color( 1, 1, 1, 0 )
-margin_top = 435.0
+margin_top = 609.0
 margin_right = 1342.0
-margin_bottom = 455.0
+margin_bottom = 629.0
 rect_min_size = Vector2( 0, 20 )
 
 [node name="Actions" type="HBoxContainer" parent="UI/Settings"]
-margin_top = 485.0
+margin_top = 659.0
 margin_right = 1342.0
-margin_bottom = 542.0
+margin_bottom = 716.0
 custom_constants/separation = 50
 
 [node name="Apply" type="Button" parent="UI/Settings/Actions"]

--- a/menu/settings.gd
+++ b/menu/settings.gd
@@ -34,6 +34,7 @@ enum Resolution {
 
 var gi_quality = GIQuality.LOW
 var aa_quality = AAQuality.AA_2X
+var shadow_enabled = true
 var ssao_quality = SSAOQuality.DISABLED
 var bloom_quality = BloomQuality.HIGH
 var resolution = Resolution.NATIVE
@@ -66,6 +67,9 @@ func load_settings():
 	if "aa" in d:
 		aa_quality = int(d.aa)
 
+	if "shadow_enabled" in d:
+		shadow_enabled = bool(d.shadow_enabled)
+
 	if "ssao" in d:
 		ssao_quality = int(d.ssao)
 
@@ -84,5 +88,5 @@ func save_settings():
 	var error = f.open("user://settings.json", File.WRITE)
 	assert(not error)
 
-	var d = { "gi":gi_quality, "aa":aa_quality, "ssao":ssao_quality, "bloom":bloom_quality, "resolution":resolution, "fullscreen":fullscreen }
+	var d = { "gi":gi_quality, "aa":aa_quality, "shadow_enabled":shadow_enabled, "ssao":ssao_quality, "bloom":bloom_quality, "resolution":resolution, "fullscreen":fullscreen }
 	f.store_line(to_json(d))


### PR DESCRIPTION
Disabling shadows reduces the number of draw calls significantly, which improves rendering performance a lot.

Since the demo doesn't have too many bright point lights, the visual difference isn't that noticeable (except when walking under a light).

This will come particularly handy on integrated graphics and on mobile (once https://github.com/godotengine/tps-demo/pull/118 is merged).

## Benchmark

FPS over time when following the path from spawn to the reactor room. Using the default graphics settings in 2560×1440 on a GeForce GTX 1080:

![image](https://user-images.githubusercontent.com/180032/183291811-ebc8a717-eefc-4f50-b958-a34970a61c3b.png)