### PR TITLE
Apply gravity to Red Robot while idle

### DIFF
--- a/enemies/red_robot/red_robot.gd
+++ b/enemies/red_robot/red_robot.gd
@@ -143,6 +143,7 @@ func _physics_process(delta):
 
 	if not player:
 		animation_tree["parameters/state/current"] = 0 # Go idle.
+		velocity = move_and_slide(gravity * delta, Vector3.UP)
 		return
 
 	if state == State.APPROACH:


### PR DESCRIPTION
When the player first enters a red robot's detection collider, it drops to the floor and then approaches the player.  This is because they are placed slightly above the ground in `level.tscn`, as it is somewhat hard to get just perfect.

I added a line in `red_robot.gd` to apply gravity while it is idling, so it doesn't just hover there.