### PR TITLE
Fix occluder shape placement in the level causing too much occlusion

### DIFF
--- a/level/level.tscn
+++ b/level/level.tscn
@@ -52,11 +52,11 @@ polygon_points = PoolVector2Array( 3.52376, -6.08494, -24.609, -15.4054, -24.756
 [sub_resource type="OccluderShapePolygon" id=8]
 polygon_points = PoolVector2Array( 3.52376, -6.08494, -24.609, -15.4054, -24.7569, -5.0943, 2.58312, -12.1537 )
 
-[sub_resource type="OccluderShapePolygon" id=9]
-polygon_points = PoolVector2Array( 3.52376, -6.08494, -24.609, -15.4054, -24.7569, -5.0943, 2.58312, -12.1537 )
+[sub_resource type="OccluderShapePolygon" id=25]
+polygon_points = PoolVector2Array( -15.2363, -5.2488, -24.609, -15.4054, -24.7569, -5.0943, -15.5928, -15.4052 )
 
 [sub_resource type="OccluderShapePolygon" id=10]
-polygon_points = PoolVector2Array( 3.52376, -6.08494, -24.609, -15.4054, -24.7569, -5.0943, 2.58312, -12.1537 )
+polygon_points = PoolVector2Array( -2.63329, -5.34279, -24.609, -15.4054, -24.7871, -4.74745, -2.88881, -15.435 )
 
 [sub_resource type="OccluderShapePolygon" id=17]
 polygon_points = PoolVector2Array( -41.5669, 1.58709, -28.542, -5.7378, -31.1337, -32.2378, -52.4377, -8.12289 )
@@ -65,10 +65,10 @@ polygon_points = PoolVector2Array( -41.5669, 1.58709, -28.542, -5.7378, -31.1337
 polygon_points = PoolVector2Array( -37.8557, -2.03779, -59.7506, 22.3384, -72.8289, 15.9366, -45.4469, -9.83544 )
 
 [sub_resource type="OccluderShapePolygon" id=19]
-polygon_points = PoolVector2Array( -69.3142, 28.2186, -58.847, 13.9716, -68.5458, 9.02338, -83.278, 26.0792 )
+polygon_points = PoolVector2Array( -68.8659, 27.1543, -60.2739, 13.1591, -68.5458, 9.02338, -83.278, 26.0792 )
 
 [sub_resource type="OccluderShapePolygon" id=20]
-polygon_points = PoolVector2Array( -78.9044, 19.1323, -63.3689, 30.6341, -75.765, 61.9673, -92.5688, 54.2322 )
+polygon_points = PoolVector2Array( -78.9044, 19.1323, -64.1978, 30.7626, -75.765, 61.9673, -92.5688, 54.2322 )
 
 [sub_resource type="OccluderShapePolygon" id=4]
 polygon_points = PoolVector2Array( 10.3326, -34.1447, 10.3129, 3.47539, 7.38751, 3.41635, 6.75379, -34.3113 )
@@ -232,39 +232,39 @@ transform = Transform( -0.314444, -0.0875491, 0.94523, -0.0317649, 0.996151, 0.0
 shape = SubResource( 24 )
 
 [node name="Catwalk" type="Occluder" parent="Occluders"]
-transform = Transform( 0.9958, -0.0175599, 0.0898516, 0.0257674, 0.995516, -0.0910177, -0.0878505, 0.0929507, 0.991788, 30.6936, 4.17444, 93.1516 )
+transform = Transform( 0.9958, -0.0175599, 0.0898516, 0.0257674, 0.995516, -0.0910177, -0.0878505, 0.0929507, 0.991788, 30.694, 4.174, 94.217 )
 shape = SubResource( 6 )
 
 [node name="Catwalk2" type="Occluder" parent="Occluders"]
-transform = Transform( 0.891993, 0.0182083, 0.451682, 0.0257674, 0.995516, -0.0910177, -0.451314, 0.0928258, 0.887524, 54.2846, 4.4742, 80.1712 )
+transform = Transform( 0.891993, 0.0182083, 0.451682, 0.0257674, 0.995516, -0.0910177, -0.451314, 0.0928258, 0.887524, 54.285, 4.474, 80.784 )
 shape = SubResource( 7 )
 
 [node name="Catwalk3" type="Occluder" parent="Occluders"]
-transform = Transform( 0.684897, 0.0487412, 0.727008, 0.0257674, 0.995516, -0.0910177, -0.728185, 0.0810708, 0.680569, 74.3772, 3.92189, 60.7251 )
+transform = Transform( 0.684897, 0.0487412, 0.727008, 0.0257674, 0.995516, -0.0910177, -0.728185, 0.0810708, 0.680569, 74.377, 3.922, 62.131 )
 shape = SubResource( 8 )
 
 [node name="Catwalk4" type="Occluder" parent="Occluders"]
 transform = Transform( 0.441835, 0.0703308, 0.894335, 0.0257674, 0.995516, -0.0910177, -0.896726, 0.0632595, 0.438041, 90.5234, 3.92189, 35.7929 )
-shape = SubResource( 9 )
+shape = SubResource( 25 )
 
 [node name="Catwalk5" type="Occluder" parent="Occluders"]
-transform = Transform( 0.135573, 0.0867267, 0.986964, 0.0257674, 0.995516, -0.0910177, -0.990432, 0.0377711, 0.13273, 96.2565, 3.92189, 11.2907 )
+transform = Transform( 0.135573, 0.0867267, 0.986964, 0.0257674, 0.995516, -0.0910177, -0.990432, 0.0377711, 0.13273, 95.945, 3.922, 11.291 )
 shape = SubResource( 10 )
 
 [node name="CatwalkFloor" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.1076, -1.14877, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.108, -1.29, 38.413 )
 shape = SubResource( 17 )
 
 [node name="CatwalkFloor2" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.1076, -1.14877, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.108, -1.239, 38.413 )
 shape = SubResource( 18 )
 
 [node name="CatwalkFloor3" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.1076, -1.14877, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.108, -1.323, 38.413 )
 shape = SubResource( 19 )
 
 [node name="CatwalkFloor4" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.1076, -1.14877, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 68.108, -1.351, 38.413 )
 shape = SubResource( 20 )
 
 [node name="Pillar1" type="Occluder" parent="Occluders"]
@@ -304,27 +304,27 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 83.3859, -2.80453, 10.5797 )
 shape = SubResource( 11 )
 
 [node name="Bridge" type="Occluder" parent="Occluders"]
-transform = Transform( 1, 0, 0, 0, 0.00188501, 0.999998, 0, -0.999998, 0.00188501, 83.3859, -6.28523, 10.5797 )
+transform = Transform( 1, 0, 0, 0, 0.00188501, 0.999998, 0, -0.999998, 0.00188501, 83.386, -6.495, 10.58 )
 shape = SubResource( 12 )
 
 [node name="RoadFloor" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.6156, -6.28523, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.616, -6.397, 38.413 )
 shape = SubResource( 13 )
 
 [node name="RoadFloorEnd" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.6156, -6.28523, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.616, -6.377, 38.413 )
 shape = SubResource( 21 )
 
 [node name="RoadFloor2" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.6156, -6.28523, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.616, -6.425, 38.413 )
 shape = SubResource( 14 )
 
 [node name="RoadFloor3" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.6156, -6.28523, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.616, -6.509, 38.413 )
 shape = SubResource( 15 )
 
 [node name="RoadFloor4" type="Occluder" parent="Occluders"]
-transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.6156, -6.28523, 38.4127 )
+transform = Transform( 0.234938, -0.972008, 0.00183225, 0, 0.00188501, 0.999998, -0.97201, -0.234938, 0.000442862, 61.616, -6.504, 38.413 )
 shape = SubResource( 16 )
 
 [node name="ReactorWallEntrance" type="Occluder" parent="Occluders"]


### PR DESCRIPTION
The occluder shape placement was too aggressive, not taking into account the fact that the camera can be brought flush to the floor by the player when looking upwards.

This closes https://github.com/godotengine/tps-demo/issues/148.