### PR TITLE
[3.x] Disable V-Sync and use optimized FPS limit

### DIFF
--- a/main/main.gd
+++ b/main/main.gd
@@ -4,6 +4,15 @@ func _ready():
 	OS.window_fullscreen = Settings.fullscreen
 	go_to_main_menu()
 
+	var max_refresh_rate = 60.0
+	for screen in OS.get_screen_count():
+		 max_refresh_rate = max(max_refresh_rate, OS.get_screen_refresh_rate(screen))
+
+	# Cap framerate to (roughly) the refresh rate of the monitor with the highest refresh rate.
+	# This allows for smooth operation while reducing power usage when V-Sync is disabled.
+	Engine.target_fps = max_refresh_rate + 1.0
+	print("Limiting FPS to %d." % Engine.target_fps)
+
 
 func go_to_main_menu():
 	var menu = ResourceLoader.load("res://menu/menu.tscn")

--- a/project.godot
+++ b/project.godot
@@ -34,6 +34,7 @@ Settings="*res://menu/settings.gd"
 window/size/width=1920
 window/size/height=1080
 window/size/fullscreen=true
+window/vsync/use_vsync=false
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 


### PR DESCRIPTION
This has some benefits over V-Sync:

- TPS demo is prone to stuttering and unstable frametimes. Disabling V-Sync helps make those issues less noticeable.
- Reduced input latency is useful for games with mouse aiming.

This comes at the cost of tearing, but it's usually not too noticeable in the TPS demo. Eventually, an option to re-enable V-Sync could be added to the options menu.

I recommend testing this PR on your own machine and see how it behaves in practice. Even on high-end GPUs, it often makes the demo feel smoother as you walk around the scene.