### PR TITLE
Add controls to the README (4.0-dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
   - [`3.1`](https://github.com/godotengine/tps-demo/tree/3.1) branch
   for Godot 3.1.x.
 
-**Note:** The repository is big and asset importing not well optimized yet,
-so expect a high wait time when opening the project for the first time.
+> **Note**
+>
+> The repository is big, so expect a high wait time when opening the project for
+> the first time.
 
 ## Git LFS
 
@@ -37,6 +39,17 @@ or [build it from source](https://github.com/godotengine/godot).
 
 You can either download from the Godot Asset Library, clone this repository, or
 [download a ZIP archive](https://github.com/godotengine/tps-demo/archive/master.zip).
+
+## Controls
+
+- Mouse or <kbd>Gamepad Right Stick</kbd>: Look around
+- <kbd>W</kbd>/<kbd>A</kbd>/<kbd>S</kbd>/<kbd>D</kbd>, <kbd>Arrow keys</kbd>, <kbd>Gamepad Left Analog Stick</kbd> or <kbd>Gamepad D-Pad</kbd>: Move
+- <kbd>Space</kbd>, <kbd>Gamepad A/Cross</kbd>: Jump
+- <kbd>Right Mouse Button</kbd>, <kbd>Gamepad Left Trigger (L2)</kbd> (press to toggle, or hold and release): Aim
+- <kbd>Left Mouse Button</kbd>, <kbd>Gamepad Right Trigger (R2)</kbd>: Shoot (only while aiming)
+- <kbd>Escape</kbd>, <kbd>Gamepad Start</kbd>: Go to main menu/quit
+- <kbd>F11</kbd> or <kbd>Alt + Enter</kbd>: Toggle fullscreen
+- <kbd>F3</kbd>: Toggle debugging information (such as FPS counter)
 
 ## Useful links
 


### PR DESCRIPTION
`4.0-dev` version of https://github.com/godotengine/tps-demo/pull/159 (identical to `master`, as the controls are the same).

This closes https://github.com/godotengine/tps-demo/issues/157.