### PR TITLE
Add mobile-optimized settings and controls

### DIFF
--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -124,6 +124,17 @@ func _ready():
 	]:
 		_make_button_group(menu)
 
+	if Settings.is_mobile:
+		# Hide settings that are not effective or relevant on mobile platforms.
+		for menu in [
+			display_mode_menu, vsync_menu, scale_filter_menu, taa_menu, gi_type_menu, gi_quality_menu,
+			ssao_menu, ssil_menu, volumetric_fog_menu,
+		]:
+			menu.visible = false
+
+			# Mobile GPUs only support MSAA up to 4×.
+			msaa_8x.visible = false
+
 func _process(_delta):
 	if loading.visible:
 		var progress = []


### PR DESCRIPTION
- Related to https://github.com/godotengine/tps-demo/pull/118.

The TPS demo can now run on mobile devices. Basic touch controls are provided (use the left side of the screen to move, right side to look, hold middle-right edge to aim, tap in bottom-right corner to jump). The controls could certainly be improved (e.g. by having a proper virtual joystick), but suffice for testing and benchmarking needs.

When running on a mobile device, the settings menu no longer lists options that have no effect when using the Mobile rendering method. Default settings have also been optimized for mobile if running on a mobile device.

**Note:** To export the project to mobile platforms, you'll need to enable ETC2 import as requested by the Export dialog when you add an Android/iOS export preset. This is expected, as I've left it disabled to prevent import times from ballooning if you import the project only to run it on desktop platforms.

## Preview

Running on a Samsung Galaxy Z Fold4's main display with a stable 30 FPS cap:

![Screenshot_20231206_184609_Godot Third-Person Shooter Demo webp](https://github.com/godotengine/tps-demo/assets/180032/f83a8aa0-a00d-4f4a-a40f-4e0fd4e18465)

![Screenshot_20231206_184711_Godot Third-Person Shooter Demo webp](https://github.com/godotengine/tps-demo/assets/180032/5d9f2dc7-4a6a-4b4f-96e0-ad8dc5807882)

On this device, it's also possible to have a steady 40 FPS by using lower-than-default graphics settings.