### PR TITLE
Remove superfluous and wrong logic to reuse cached load

### DIFF
--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -153,11 +153,7 @@ func _on_loading_done_timer_timeout():
 func _on_play_pressed():
 	main.hide()
 	loading.show()
-	if ResourceLoader.has_cached(path):
-		multiplayer.multiplayer_peer = peer
-		emit_signal("replace_main_scene", ResourceLoader.load_threaded_get(path))
-	else:
-		ResourceLoader.load_threaded_request(path, "", true)
+	ResourceLoader.load_threaded_request(path, "", true)
 
 func _on_settings_pressed():
 	main.hide()


### PR DESCRIPTION
With threaded loading you can't try to get the result of a load request multiple times (requests and gets must be balanced). If anything, this code should have called `load()` in the positive branch of the `if`, which would return the existing instance of the resource from the cache. However, that's already what would happen anyway in a threaded load, so there's little to no point in handling it specially.

Furthermore, this project is not doing anything to keep the resource in the cache so the check will always fail anyway.