### PR TITLE
Made Joystick mapping match genre standards

### DIFF
--- a/door/door.gd.uid
+++ b/door/door.gd.uid
@@ -1,0 +1,1 @@
+uid://cxxcpja540pq4

--- a/door/model/door.dae.import
+++ b/door/model/door.dae.import
@@ -18,6 +18,7 @@ nodes/root_name="DoorModel"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/effects_shared/BlastMesh.glb.import
+++ b/effects_shared/BlastMesh.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/laser/BarrelSmoke.glb.import
+++ b/enemies/red_robot/laser/BarrelSmoke.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/laser/LaserShader.gdshader.uid
+++ b/enemies/red_robot/laser/LaserShader.gdshader.uid
@@ -1,0 +1,1 @@
+uid://1xk3pvalrgoy

--- a/enemies/red_robot/laser/impact_effect/EmissionAlbedoParticle.gdshader.uid
+++ b/enemies/red_robot/laser/impact_effect/EmissionAlbedoParticle.gdshader.uid
@@ -1,0 +1,1 @@
+uid://b85lk6t1atpai

--- a/enemies/red_robot/laser/impact_effect/EmissionEmbers.gdshader.uid
+++ b/enemies/red_robot/laser/impact_effect/EmissionEmbers.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cixxurrt7n6fu

--- a/enemies/red_robot/laser/impact_effect/LightRaysMesh.glb.import
+++ b/enemies/red_robot/laser/impact_effect/LightRaysMesh.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/laser/impact_effect/blast.gd.uid
+++ b/enemies/red_robot/laser/impact_effect/blast.gd.uid
@@ -1,0 +1,1 @@
+uid://cqmpjwk1ukfv6

--- a/enemies/red_robot/laser/smoke.gdshader.uid
+++ b/enemies/red_robot/laser/smoke.gdshader.uid
@@ -1,0 +1,1 @@
+uid://be8totf3aojon

--- a/enemies/red_robot/laser/smoke.tres
+++ b/enemies/red_robot/laser/smoke.tres
@@ -1,6 +1,6 @@
 [gd_resource type="ShaderMaterial" load_steps=5 format=3 uid="uid://bhf6kwdlc7f5h"]
 
-[ext_resource type="Shader" path="res://enemies/red_robot/laser/smoke.gdshader" id="1_j0r3f"]
+[ext_resource type="Shader" uid="uid://be8totf3aojon" path="res://enemies/red_robot/laser/smoke.gdshader" id="1_j0r3f"]
 [ext_resource type="Texture2D" uid="uid://i5ll5xqsm55y" path="res://enemies/red_robot/laser/BarrelSmokeTexture.png" id="2"]
 
 [sub_resource type="FastNoiseLite" id="29"]

--- a/enemies/red_robot/model/red_robot.glb.import
+++ b/enemies/red_robot/model/red_robot.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/parts/part.gd.uid
+++ b/enemies/red_robot/parts/part.gd.uid
@@ -1,0 +1,1 @@
+uid://d0o60urlkdkyt

--- a/enemies/red_robot/parts/part_disappear_effect/part_disappear.gd.uid
+++ b/enemies/red_robot/parts/part_disappear_effect/part_disappear.gd.uid
@@ -1,0 +1,1 @@
+uid://d1nsn3vhi610p

--- a/enemies/red_robot/parts/part_head.glb.import
+++ b/enemies/red_robot/parts/part_head.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/parts/part_shield.glb.import
+++ b/enemies/red_robot/parts/part_shield.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/parts/ray.gdshader.uid
+++ b/enemies/red_robot/parts/ray.gdshader.uid
@@ -1,0 +1,1 @@
+uid://dnvs87s884opj

--- a/enemies/red_robot/parts/ray.glb.import
+++ b/enemies/red_robot/parts/ray.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/parts/sparks_effect/SparkParticle.glb.import
+++ b/enemies/red_robot/parts/sparks_effect/SparkParticle.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/enemies/red_robot/parts/sparks_effect/SparkShader.gdshader.uid
+++ b/enemies/red_robot/parts/sparks_effect/SparkShader.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cmhku1vd06f3y

--- a/enemies/red_robot/red_robot.gd.uid
+++ b/enemies/red_robot/red_robot.gd.uid
@@ -1,0 +1,1 @@
+uid://dvgq23gddw6m0

--- a/enemies/red_robot/smoke.gdshader.uid
+++ b/enemies/red_robot/smoke.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cqenk2m4g3x0u

--- a/level/debug.gd.uid
+++ b/level/debug.gd.uid
@@ -1,0 +1,1 @@
+uid://c1d5djsc1jwnu

--- a/level/forklift/flying_forklift.gd.uid
+++ b/level/forklift/flying_forklift.gd.uid
@@ -1,0 +1,1 @@
+uid://bwgpfta5o36ic

--- a/level/forklift/flying_forklift.glb.import
+++ b/level/forklift/flying_forklift.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="FlyingForkliftModel"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/level/geometry/models/core.glb.import
+++ b/level/geometry/models/core.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="CoreModel"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/level/geometry/models/lights.glb.import
+++ b/level/geometry/models/lights.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="LightsModel"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/level/geometry/models/props.glb.import
+++ b/level/geometry/models/props.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="PropsModel"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/level/geometry/models/structure.glb.import
+++ b/level/geometry/models/structure.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="StructureModel"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/level/level.gd.uid
+++ b/level/level.gd.uid
@@ -1,0 +1,1 @@
+uid://bi8nu53vbg807

--- a/level/textures/structure/Core/CoreOutLight.glb.import
+++ b/level/textures/structure/Core/CoreOutLight.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/main/main.gd.uid
+++ b/main/main.gd.uid
@@ -1,0 +1,1 @@
+uid://dbyyfgdfnxvyb

--- a/main/main.tscn
+++ b/main/main.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://dmp13e1xswsm0"]
 
-[ext_resource type="Script" path="res://main/main.gd" id="1"]
+[ext_resource type="Script" uid="uid://dbyyfgdfnxvyb" path="res://main/main.gd" id="1"]
 
 [node name="main" type="Node"]
 script = ExtResource("1")

--- a/menu/font/PT_Sans-Web-Bold.ttf.import
+++ b/menu/font/PT_Sans-Web-Bold.ttf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/menu/menu.gd.uid
+++ b/menu/menu.gd.uid
@@ -1,0 +1,1 @@
+uid://b4kx21o7wp52l

--- a/menu/settings.gd.uid
+++ b/menu/settings.gd.uid
@@ -1,0 +1,1 @@
+uid://bpuqsh1vq0kar

--- a/player/bullet/bullet.gd.uid
+++ b/player/bullet/bullet.gd.uid
@@ -1,0 +1,1 @@
+uid://bmie1u881qnbv

--- a/player/camera_noise_shake_effect.gd.uid
+++ b/player/camera_noise_shake_effect.gd.uid
@@ -1,0 +1,1 @@
+uid://bu3l44qwun0qv

--- a/player/model/muzzle_flash_particle_mesh.glb.import
+++ b/player/model/muzzle_flash_particle_mesh.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/player/model/player.glb.import
+++ b/player/model/player.glb.import
@@ -18,6 +18,7 @@ nodes/root_name="Scene Root"
 nodes/apply_root_scale=true
 nodes/root_scale=1.0
 nodes/import_as_skeleton_bones=false
+nodes/use_node_type_suffixes=true
 meshes/ensure_tangents=true
 meshes/generate_lods=true
 meshes/create_shadow_meshes=true

--- a/player/player.gd.uid
+++ b/player/player.gd.uid
@@ -1,0 +1,1 @@
+uid://8dbghtrr148l

--- a/player/player_input.gd.uid
+++ b/player/player_input.gd.uid
@@ -1,0 +1,1 @@
+uid://s6npr2qmvgwx

--- a/project.godot
+++ b/project.godot
@@ -90,7 +90,7 @@ ui_down={
 move_left={
 "deadzone": 0.2,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":13,"pressure":0.0,"pressed":true,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
@@ -98,7 +98,7 @@ move_left={
 move_right={
 "deadzone": 0.2,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":14,"pressure":0.0,"pressed":true,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
@@ -106,7 +106,7 @@ move_right={
 move_forward={
 "deadzone": 0.2,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":-1.0,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":11,"pressure":0.0,"pressed":true,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
@@ -114,7 +114,7 @@ move_forward={
 move_back={
 "deadzone": 0.2,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":1.0,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":12,"pressure":0.0,"pressed":true,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
@@ -128,19 +128,19 @@ jump={
 aim={
 "deadzone": 0.2,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
 ]
 }
 shoot={
 "deadzone": 0.2,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":7,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":1.0,"script":null)
 ]
 }
 quit={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194305,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 view_left={


### PR DESCRIPTION
There was very wierd joystick mapping. This PR maps actions to familiar for all shooter players buttons:

`L2` or `LT` - aim
`R2` or `RT` - shoot
`D-Pad left, right, up, down` - move left, right, up, down respectively
`Options` - quit 