### PR TITLE
Modify options to use Screen-space Antialiasing and add SMAA

### DIFF
--- a/menu/menu.gd
+++ b/menu/menu.gd
@@ -66,9 +66,10 @@ var peer : MultiplayerPeer = OfflineMultiplayerPeer.new()
 @onready var msaa_4x = msaa_menu.get_node("4X")
 @onready var msaa_8x = msaa_menu.get_node("8X")
 
-@onready var fxaa_menu = settings_menu.get_node("FXAA")
-@onready var fxaa_disabled = fxaa_menu.get_node("Disabled")
-@onready var fxaa_enabled = fxaa_menu.get_node("Enabled")
+@onready var screen_space_aa_menu = settings_menu.get_node("ScreenSpaceAA")
+@onready var screen_space_aa_disabled = screen_space_aa_menu.get_node("Disabled")
+@onready var screen_space_aa_fxaa = screen_space_aa_menu.get_node("FXAA")
+@onready var screen_space_aa_smaa = screen_space_aa_menu.get_node("SMAA")
 
 @onready var shadow_mapping_menu = settings_menu.get_node("ShadowMapping")
 @onready var shadow_mapping_disabled = shadow_mapping_menu.get_node("Disabled")
@@ -116,7 +117,7 @@ func _ready():
 	play_button.grab_focus()
 	for menu in [
 		display_mode_menu, vsync_menu, max_fps_menu, resolution_scale_menu, scale_filter_menu,
-		taa_menu, msaa_menu, fxaa_menu, shadow_mapping_menu, gi_type_menu, gi_quality_menu,
+		taa_menu, msaa_menu, screen_space_aa_menu, shadow_mapping_menu, gi_type_menu, gi_quality_menu,
 		ssao_menu, ssil_menu, bloom_menu, volumetric_fog_menu,
 	]:
 		_make_button_group(menu)
@@ -241,10 +242,12 @@ func _on_settings_pressed():
 	elif Settings.config_file.get_value("rendering", "msaa") == Viewport.MSAA_8X:
 		msaa_8x.button_pressed = true
 
-	if not Settings.config_file.get_value("rendering", "fxaa"):
-		fxaa_disabled.button_pressed = true
-	else:
-		fxaa_enabled.button_pressed = true
+	if Settings.config_file.get_value("rendering", "screen_space_aa") == Viewport.SCREEN_SPACE_AA_DISABLED:
+		screen_space_aa_disabled.button_pressed = true
+	elif Settings.config_file.get_value("rendering", "screen_space_aa") == Viewport.SCREEN_SPACE_AA_FXAA:
+		screen_space_aa_fxaa.button_pressed = true
+	elif Settings.config_file.get_value("rendering", "screen_space_aa") == Viewport.SCREEN_SPACE_AA_SMAA:
+		screen_space_aa_smaa.button_pressed = true
 
 	if not Settings.config_file.get_value("rendering", "shadow_mapping"):
 		shadow_mapping_disabled.button_pressed = true
@@ -364,7 +367,13 @@ func _on_apply_pressed():
 		Settings.config_file.set_value("rendering", "msaa", Viewport.MSAA_8X)
 
 	Settings.config_file.set_value("rendering", "shadow_mapping", shadow_mapping_enabled.button_pressed)
-	Settings.config_file.set_value("rendering", "fxaa", fxaa_enabled.button_pressed)
+
+	if screen_space_aa_disabled.button_pressed:
+		Settings.config_file.set_value("rendering", "screen_space_aa", Viewport.SCREEN_SPACE_AA_DISABLED)
+	elif screen_space_aa_fxaa.button_pressed:
+		Settings.config_file.set_value("rendering", "screen_space_aa", Viewport.SCREEN_SPACE_AA_FXAA)
+	elif screen_space_aa_smaa.button_pressed:
+		Settings.config_file.set_value("rendering", "screen_space_aa", Viewport.SCREEN_SPACE_AA_SMAA)
 
 	if ssao_disabled.button_pressed:
 		Settings.config_file.set_value("rendering", "ssao_quality", -1)

--- a/menu/menu.tscn
+++ b/menu/menu.tscn
@@ -543,30 +543,38 @@ size_flags_horizontal = 3
 toggle_mode = true
 text = "8×"
 
-[node name="FXAA" type="HBoxContainer" parent="UI/Settings"]
+[node name="ScreenSpaceAA" type="HBoxContainer" parent="UI/Settings"]
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="Label" type="Label" parent="UI/Settings/FXAA"]
+[node name="Label" type="Label" parent="UI/Settings/ScreenSpaceAA"]
 custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
 size_flags_vertical = 1
-text = "Fast Approximate Antialiasing:"
+text = "Screen-space Antialiasing:"
 
-[node name="Disabled" type="Button" parent="UI/Settings/FXAA"]
+[node name="Disabled" type="Button" parent="UI/Settings/ScreenSpaceAA"]
 modulate = Color(0.376471, 1, 0.376471, 1)
 layout_mode = 2
 size_flags_horizontal = 3
 toggle_mode = true
 text = "Disabled"
 
-[node name="Enabled" type="Button" parent="UI/Settings/FXAA"]
+[node name="FXAA" type="Button" parent="UI/Settings/ScreenSpaceAA"]
 modulate = Color(0.376471, 1, 0.376471, 1)
 layout_mode = 2
 size_flags_horizontal = 3
 toggle_mode = true
 keep_pressed_outside = true
-text = "Enabled"
+text = "FXAA"
+
+[node name="SMAA" type="Button" parent="UI/Settings/ScreenSpaceAA"]
+modulate = Color(1, 1, 0.313726, 1)
+layout_mode = 2
+size_flags_horizontal = 3
+toggle_mode = true
+keep_pressed_outside = true
+text = "SMAA"
 
 [node name="ShadowMapping" type="HBoxContainer" parent="UI/Settings"]
 layout_mode = 2

--- a/menu/settings.gd
+++ b/menu/settings.gd
@@ -25,7 +25,7 @@ const DEFAULTS = {
 	rendering = {
 		taa = false,
 		msaa = Viewport.MSAA_DISABLED,
-		fxaa = false,
+		screen_space_aa = Viewport.SCREEN_SPACE_AA_DISABLED,
 		shadow_mapping = true,
 		gi_type = GIType.VOXEL_GI,
 		gi_quality = GIQuality.LOW,
@@ -72,7 +72,7 @@ func apply_graphics_settings(window: Window, environment: Environment, scene_roo
 
 	window.use_taa = Settings.config_file.get_value("rendering", "taa")
 	window.msaa_3d = Settings.config_file.get_value("rendering", "msaa")
-	window.screen_space_aa = Viewport.SCREEN_SPACE_AA_FXAA if Settings.config_file.get_value("rendering", "fxaa") else Viewport.SCREEN_SPACE_AA_DISABLED
+	window.screen_space_aa = Settings.config_file.get_value("rendering", "screen_space_aa")
 
 	if not Settings.config_file.get_value("rendering", "shadow_mapping"):
 		# Disable shadows for all lights present during level load,


### PR DESCRIPTION
Instead of being an option that enables or disables FXAA, it now modifies the screen-space AA.

Before

`Fast Approximate Antialiasing: Disabled Enabled`

After:

`Screen-space Antialiasing: Disabled FXAA SMAA`

~~This is mostly done in preparation for https://github.com/godotengine/godot/pull/102330, where a third button, SMAA, would be added later (I did these changes to test SMAA in the demo, this is just it but partly reverted to avoid errors).~~

**Update:** The PR mentioned above got merged, so this one was updated to include it. Note that this won't be compatible with 4.4 or lower anymore.