### PR TITLE
Fix enemy attack ray calculation

### DIFF
--- a/enemies/red_robot/red_robot.gd
+++ b/enemies/red_robot/red_robot.gd
@@ -107,7 +107,7 @@ func hit() -> void:
 func shoot() -> void:
 	var gt: Transform3D = ray_from.global_transform
 	var ray_origin: Vector3 = ray_from.global_transform.origin
-	var ray_dir: Vector3 = -gt.basis.z
+	var ray_dir: Vector3 = gt.basis.y
 	var max_dist: float = 1000.0
 
 	var col: Dictionary = get_world_3d().direct_space_state.intersect_ray(PhysicsRayQueryParameters3D.create(ray_origin, ray_origin + ray_dir * max_dist, 0xFFFFFFFF, [self] ))

--- a/enemies/red_robot/red_robot.gd
+++ b/enemies/red_robot/red_robot.gd
@@ -107,6 +107,7 @@ func hit() -> void:
 func shoot() -> void:
 	var gt: Transform3D = ray_from.global_transform
 	var ray_origin: Vector3 = ray_from.global_transform.origin
+	# The RayCast3D is rotated 90 degrees inside the BoneAttachment3D.
 	var ray_dir: Vector3 = gt.basis.y
 	var max_dist: float = 1000.0
 


### PR DESCRIPTION
This has been bothering me since I've seen the very first version of this demo.

Since the RayCast3D is rotated 90 degrees inside the BoneAttachment3D, the laser 'explosion/hit' was being shot downward into the ground near the enemy's feet instead of toward the target.

Before:

https://github.com/user-attachments/assets/5f5ee76e-9b7e-496a-a944-4b66aebc8e07

After:

https://github.com/user-attachments/assets/345e0fdd-422d-4e5d-8bc6-7276fa186eaa

